### PR TITLE
Fix for avoid send the same on/off command than device state

### DIFF
--- a/smartir/media_player.py
+++ b/smartir/media_player.py
@@ -197,7 +197,8 @@ class SmartIRMediaPlayer(MediaPlayerDevice, RestoreEntity):
 
     async def async_turn_off(self):
         """Turn the media player off."""
-        await self.send_command(self._commands['off'])
+        if self._power_sensor is None or self._state is not STATE_OFF:
+            await self.send_command(self._commands['off'])
         
         if self._power_sensor is None:
             self._state = STATE_OFF
@@ -206,7 +207,8 @@ class SmartIRMediaPlayer(MediaPlayerDevice, RestoreEntity):
 
     async def async_turn_on(self):
         """Turn the media player off."""
-        await self.send_command(self._commands['on'])
+        if self._power_sensor is None or self._state is not STATE_ON:
+            await self.send_command(self._commands['on'])
 
         if self._power_sensor is None:
             self._state = STATE_ON


### PR DESCRIPTION
For some media player devices (like TVs) the IR command for ON/OFF is the same, I have detected that always is sending the ON/OFF command, without check the power_sensor status.

I have added this validation for avoid turn_off the TV if I call "turn_on" while the device is power on (from scripts, automations, etc).