### PR TITLE
Add config option to override source names

### DIFF
--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -27,13 +27,15 @@ CONF_UNIQUE_ID = 'unique_id'
 CONF_DEVICE_CODE = 'device_code'
 CONF_CONTROLLER_DATA = "controller_data"
 CONF_POWER_SENSOR = 'power_sensor'
+CONF_SOURCE_NAMES = 'source_names'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_UNIQUE_ID): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_DEVICE_CODE): cv.positive_int,
     vol.Required(CONF_CONTROLLER_DATA): cv.string,
-    vol.Optional(CONF_POWER_SENSOR): cv.entity_id
+    vol.Optional(CONF_POWER_SENSOR): cv.entity_id,
+    vol.Optional(CONF_SOURCE_NAMES): dict
 })
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -118,6 +120,13 @@ class SmartIRMediaPlayer(MediaPlayerDevice, RestoreEntity):
 
         if 'sources' in self._commands and self._commands['sources'] is not None:
             self._support_flags = self._support_flags | SUPPORT_SELECT_SOURCE
+
+            for source, new_name in config.get(CONF_SOURCE_NAMES, {}).items():
+                if source in self._commands['sources']:
+                    if new_name is not None:
+                        self._commands['sources'][new_name] = self._commands['sources'][source]
+
+                    del self._commands['sources'][source]
 
             #Sources list
             for key in self._commands['sources']:

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -13,23 +13,6 @@ Find your device's brand code [here](MEDIA_PLAYER.md#available-codes-for-tv-devi
 **power_sensor** (Optional): *entity_id* for a sensor that monitors whether your device is actually On or Off. This may be a power monitor sensor. (Accepts only on/off states)<br />
 **source_names** (Optional): Override the names of sources as displayed in HomeAssistant (see below)<br />
 
-### Overriding Source Names
-
-Source names in device files are usually set to the name that the media player uses. These often aren't very descriptive, so you can override these names in the configuration file. You can also remove a source by setting its name to `null`
-
-```yaml
-media_player:
-  - platform: smartir
-    name: Living room TV
-    unique_id: living_room_tv
-    device_code: 1000
-    controller_data: 192.168.10.10
-    source_names:
-      HDMI1: DVD Player
-      HDMI2: Xbox
-      VGA: null
-```
-
 ## Example (using broadlink controller):
 ```yaml
 smartir:
@@ -77,6 +60,22 @@ media_player:
     device_code: 3000
     controller_data: home-assistant/living-room-tv/command
     power_sensor: binary_sensor.tv_power
+```
+
+### Overriding Source Names
+Source names in device files are usually set to the name that the media player uses. These often aren't very descriptive, so you can override these names in the configuration file. You can also remove a source by setting its name to `null`
+
+```yaml
+media_player:
+  - platform: smartir
+    name: Living room TV
+    unique_id: living_room_tv
+    device_code: 1000
+    controller_data: 192.168.10.10
+    source_names:
+      HDMI1: DVD Player
+      HDMI2: Xbox
+      VGA: null
 ```
 
 ## Available codes for TV devices:

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -11,6 +11,24 @@ Find your device's brand code [here](MEDIA_PLAYER.md#available-codes-for-tv-devi
 **device_code** (Required): ...... (Accepts only positive numbers)<br />
 **controller_data** (Required): The data required for the controller to function. Enter the IP address of the Broadlink device **(must be an already configured device)**, or the entity id of the Xiaomi IR controller, or the MQTT topic on which to send commands.<br />
 **power_sensor** (Optional): *entity_id* for a sensor that monitors whether your device is actually On or Off. This may be a power monitor sensor. (Accepts only on/off states)<br />
+**source_names** (Optional): Override the names of sources as displayed in HomeAssistant (see below)<br />
+
+### Overriding Source Names
+
+Source names in device files are usually set to the name that the media player uses. These often aren't very descriptive, so you can override these names in the configuration file. You can also remove a source by setting its name to `null`
+
+```yaml
+media_player:
+  - platform: smartir
+    name: Living room TV
+    unique_id: living_room_tv
+    device_code: 1000
+    controller_data: 192.168.10.10
+    source_names:
+      HDMI1: DVD Player
+      HDMI2: Xbox
+      VGA: null
+```
 
 ## Example (using broadlink controller):
 ```yaml


### PR DESCRIPTION
This PR adds a config option to media player devices to allow the user to override the names of media sources from what is set in the device file.

For example, in my setup, HDMI1 is my Chromecast, HDMI2 is my Nintendo Switch, and HDMI3 is my Steam Link. I also have a VGA input that I don't use. With this MR, I can have a config like:

```yaml
  - platform: smartir
    name: Living room TV
    unique_id: living_room_tv
    device_code: 1000
    controller_data: 192.168.10.10
    source_names:
      HDMI1: Chromecast
      HDMI2: Nintendo Switch
      HDMI3: Steam Link
      VGA: null
```

The VGA input doesn't show up, removing clutter and I no longer have to remember which input is for which device