### PR TITLE
Exposing hvac_mode to attributes

### DIFF
--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -255,6 +255,7 @@ class SmartIRClimate(ClimateDevice, RestoreEntity):
     def device_state_attributes(self) -> dict:
         """Platform specific attributes."""
         return {
+            'hvac_mode': self._hvac_mode,
             'last_on_operation': self._last_on_operation,
             'device_code': self._device_code,
             'manufacturer': self._manufacturer,


### PR DESCRIPTION
Exposing hvac_mode to attributes as some components in Home Assistant can use it.