### PR TITLE
[RFE] Added support for device_class property on media_player devices

### DIFF
--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -22,12 +22,14 @@ from .controller import Controller
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "SmartIR Media Player"
+DEFAULT_DEVICE_CLASS = "tv"
 
 CONF_UNIQUE_ID = 'unique_id'
 CONF_DEVICE_CODE = 'device_code'
 CONF_CONTROLLER_DATA = "controller_data"
 CONF_POWER_SENSOR = 'power_sensor'
 CONF_SOURCE_NAMES = 'source_names'
+CONF_DEVICE_CLASS = 'device_class'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_UNIQUE_ID): cv.string,
@@ -35,7 +37,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DEVICE_CODE): cv.positive_int,
     vol.Required(CONF_CONTROLLER_DATA): cv.string,
     vol.Optional(CONF_POWER_SENSOR): cv.entity_id,
-    vol.Optional(CONF_SOURCE_NAMES): dict
+    vol.Optional(CONF_SOURCE_NAMES): dict,
+    vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): cv.string
 })
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -97,6 +100,8 @@ class SmartIRMediaPlayer(MediaPlayerDevice, RestoreEntity):
         self._sources_list = []
         self._source = None
         self._support_flags = 0
+
+        self._device_class = config.get(CONF_DEVICE_CLASS)
 
         #Supported features
         if 'off' in self._commands and self._commands['off'] is not None:
@@ -164,6 +169,11 @@ class SmartIRMediaPlayer(MediaPlayerDevice, RestoreEntity):
     def name(self):
         """Return the name of the media player."""
         return self._name
+
+    @property
+    def device_class(self):
+        """Return the device_class of the media player."""
+        return self._device_class
 
     @property
     def state(self):


### PR DESCRIPTION
This property is required to get the media_player exported in HomeKit components so I added it as optional with a `tv` as a default value if not specified.

https://www.home-assistant.io/components/homekit/#supported-components