### PR TITLE
Add model references to Daikin 1100 codes (FTXS**BVMB and FTXS**CVMB)

### DIFF
--- a/codes/climate/1100.json
+++ b/codes/climate/1100.json
@@ -1,7 +1,10 @@
 {
   "manufacturer": "Daikin",
   "supportedModels": [
-    "Unknown"
+    "FTXS25CVMB",
+    "FTXS35CVMB",
+    "FTXS60BVMB",
+    "FVXS25BVMB"
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",

--- a/codes/climate/3100.json
+++ b/codes/climate/3100.json
@@ -1,7 +1,10 @@
 {
   "manufacturer": "Daikin",
   "supportedModels": [
-    "Unknown"
+    "FTXS25CVMB",
+    "FTXS35CVMB",
+    "FTXS60BVMB",
+    "FVXS25BVMB"
   ],
   "supportedController": "Xiaomi",
   "commandsEncoding": "Raw",

--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -115,13 +115,13 @@ Below are the code files created by the people in the community. Before you star
 [1083](../codes/climate/1083.json)|RAS-32CNH2|Broadlink
 
 #### Daikin
-| Code | Supported Models | Controller | 
+| Code | Supported Models | Controller |
 | ------------- | -------------------------- | ------------- |
-[1100](../codes/climate/1100.json)|Unknown model|Broadlink
+[1100](../codes/climate/1100.json)|FTXS25CVMB<br>FTXS35CVMB<br>FTXS60BVMB<br>FVXS25BVMB|Broadlink
 [1101](../codes/climate/1101.json)|FTXS20LVMA<br>FTXS25LVMA<br>FTXS35LVMA<br>FTXS46LVMA<br>FTXS50LVMA<br>FTXS60LVMA<br>FTXS71LVMA<br>FTXS85LVMA<br>FTXS95LVMA<br>FTXM35M<br>FVXM35F|Broadlink
 [1102](../codes/climate/1102.json)|FTV20AXV14|Broadlink
 [1103](../codes/climate/1103.json)|Unknown model|Broadlink
-[3100](../codes/climate/3100.json)|Unknown model|Xiaomi
+[3100](../codes/climate/3100.json)|FTXS25CVMB<br>FTXS35CVMB<br>FTXS60BVMB<br>FVXS25BVMB|Xiaomi
 
 #### Mitsubishi Electric
 | Code | Supported Models | Controller |


### PR DESCRIPTION
Add missing model names / references to codes 1100.