### PR TITLE
Added ability to tune to any numeric channel, play, pause and stop functions to media player.

### DIFF
--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -127,8 +127,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
             self._support_flags = self._support_flags | SUPPORT_PLAY_MEDIA 
         
         if 'play' in self._commands and self._commands['play'] is not None:
-            self._support_flags = self._support_flags | SUPPORT_PLAY | \
-                SUPPORT_PLAY_MEDIA | SUPPORT_PAUSE | SUPPORT_STOP
+            self._support_flags = self._support_flags | SUPPORT_PLAY | SUPPORT_PAUSE | SUPPORT_STOP
        
        if 'sources' in self._commands and self._commands['sources'] is not None:
             self._support_flags = self._support_flags | SUPPORT_SELECT_SOURCE

--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -129,7 +129,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         if 'play' in self._commands and self._commands['play'] is not None:
             self._support_flags = self._support_flags | SUPPORT_PLAY | SUPPORT_PAUSE | SUPPORT_STOP
        
-       if 'sources' in self._commands and self._commands['sources'] is not None:
+        if 'sources' in self._commands and self._commands['sources'] is not None:
             self._support_flags = self._support_flags | SUPPORT_SELECT_SOURCE
 
             for source, new_name in config.get(CONF_SOURCE_NAMES, {}).items():


### PR DESCRIPTION
With the support for changing channels now available in the Alexa component, the additions of these  extra  functions in media_play.py will now allow a user to say "Alexa, tune to channel 125 on TV" or say "Alexa tune to CityTV on TV" , or "Alexa, Pause DVR", etc.  The functions will then send the appropriate digits sequentially to the selected controller.

The changes needed in the codes files to support this require the addition of codes for each individual key. ie key_0, key_1, key_2, enter,play,pause,stop, etc in the commands section.

Optionally, the addition of a channels subsection will add the ability to tune by channel name from Alexa. ie: "channels": {
	   "city": "7",
	   "citytv": "7",
       "pulse24": "24",
       "amc": "31",
	  }



