### PR TITLE
Add support for a delay between commands

### DIFF
--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -105,6 +105,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         self._min_temperature = device_data['minTemperature']
         self._max_temperature = device_data['maxTemperature']
         self._precision = device_data['precision']
+        self._delay = device_data.get('delay')
 
         valid_hvac_modes = [x for x in device_data['operationModes'] if x in HVAC_MODES]
 
@@ -336,6 +337,9 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
 
                 await self._controller.send(
                     self._commands[operation_mode][fan_mode][target_temperature])
+
+                if self._delay:
+                    await asyncio.sleep(self._delay)
 
             except Exception as e:
                 _LOGGER.exception(e)


### PR DESCRIPTION
I was getting dropped temperature changes if commands were sent too quickly.

My Aircon needs a delay beween sending commands in order for it to be reliable.
