### PR TITLE
Add pioneer casette models

### DIFF
--- a/codes/climate/2040.json
+++ b/codes/climate/2040.json
@@ -2,7 +2,9 @@
   "manufacturer": "Pioneer",
   "supportedModels": [
     "WYS018GMFI17RL",
-    "WYS009GMFI17RL"
+    "WYS009GMFI17RL",
+    "CB018GMFILCFHD",
+    "CB012GMFILCFHD"
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",


### PR DESCRIPTION
Looking to integrate these two models I've added at home. They are Pioneer Cassette models (18k and 12k) versus the wall units already in this file.

It seems like when you have HASS setup properly with the Broadlink RM4 Mini, seems to work just fine!

Thanks to whomever did this work already.