### PR TITLE
Add type to example of HASS configuration.yaml

### DIFF
--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -23,6 +23,7 @@ switch:
   - platform: broadlink
     host: 192.168.10.10
     mac: '00:00:00:00:00:00'
+    type: rm4_mini
 
 climate:
   - platform: smartir

--- a/docs/FAN.md
+++ b/docs/FAN.md
@@ -20,6 +20,7 @@ switch:
   - platform: broadlink
     host: 192.168.10.10
     mac: '00:00:00:00:00:00'
+    type: rm4_mini
 
 fan:
   - platform: smartir

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -21,7 +21,8 @@ switch:
   - platform: broadlink
     host: 192.168.10.10
     mac: '00:00:00:00:00:00'
-    
+    type: rm4_mini
+
 media_player:
   - platform: smartir
     name: Living room TV


### PR DESCRIPTION
In my recent experience with the latest HASS. None of my send commands would work without this "Type" included in the switch: area of configuration.yaml

Putting this in as a suggestion from my recent frustration and solution.