### PR TITLE
Added chigo remote model

### DIFF
--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -329,7 +329,7 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 #### Chigo
 | Code                               | Supported Models | Controller |
 | ---------------------------------- | ---------------- | ---------- |
-| [1580](../codes/climate/1580.json) | Unknown          | Broadlink  |
+| [1580](../codes/climate/1580.json) | ZH/JT-03 (Remote)| Broadlink  |
 | [3580](../codes/climate/3580.json) | Unknown          | Xiaomi (v2)|
 
 #### Beko


### PR DESCRIPTION
compatible models: Chigo, Dantex, Tachiair, NORDSTAR PRIME, ZEN, BEKO, BXNEU 180, BXNEU 181