### PR TITLE
Update Broadlink controller

### DIFF
--- a/custom_components/smartir/controller.py
+++ b/custom_components/smartir/controller.py
@@ -85,12 +85,12 @@ class Controller():
                                     "Pronto to Base64 encoding")
 
             service_data = {
-                'host': self._controller_data,
-                'packet': command
+                ATTR_ENTITY_ID: self._controller_data,
+                'command':  'b64:' + command
             }
 
             await self.hass.services.async_call(
-                'broadlink', 'send', service_data)
+                'remote', 'send_command', service_data)
 
 
         if self._controller == XIAOMI_CONTROLLER:

--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -16,21 +16,17 @@ _Please note that the device_code field only accepts positive numbers. The .json
 **power_sensor** (Optional): *entity_id* for a sensor that monitors whether your device is actually On or Off. This may be a power monitor sensor. (Accepts only on/off states)<br />
 
 ## Example (using broadlink controller):
+Add a Broadlink RM device named "Bedroom" via config flow (read the [docs](https://www.home-assistant.io/integrations/broadlink/)).
+
 ```yaml
 smartir:
-
-switch:
-  - platform: broadlink
-    host: 192.168.10.10
-    mac: '00:00:00:00:00:00'
-    type: rm4_mini
 
 climate:
   - platform: smartir
     name: Office AC
     unique_id: office_ac
     device_code: 1000
-    controller_data: 192.168.10.10
+    controller_data: remote.bedroom_remote
     temperature_sensor: sensor.temperature
     humidity_sensor: sensor.humidity
     power_sensor: binary_sensor.ac_power

--- a/docs/FAN.md
+++ b/docs/FAN.md
@@ -13,21 +13,17 @@ Find your device's brand code [here](FAN.md#available-codes-for-fan-devices) and
 **power_sensor** (Optional): *entity_id* for a sensor that monitors whether your device is actually On or Off. This may be a power monitor sensor. (Accepts only on/off states)<br />
 
 ## Example (using broadlink controller):
+Add a Broadlink RM device named "Bedroom" via config flow (read the [docs](https://www.home-assistant.io/integrations/broadlink/)).
+
 ```yaml
 smartir:
-
-switch:
-  - platform: broadlink
-    host: 192.168.10.10
-    mac: '00:00:00:00:00:00'
-    type: rm4_mini
 
 fan:
   - platform: smartir
     name: Bedroom fan
     unique_id: bedroom_fan
     device_code: 1000
-    controller_data: 192.168.10.10
+    controller_data: remote.bedroom_remote
     power_sensor: binary_sensor.fan_power
 ```
 ## Example (using xiaomi controller):

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -14,21 +14,17 @@ Find your device's brand code [here](MEDIA_PLAYER.md#available-codes-for-tv-devi
 **source_names** (Optional): Override the names of sources as displayed in HomeAssistant (see below)<br />
 
 ## Example (using broadlink controller):
+Add a Broadlink RM device named "Bedroom" via config flow (read the [docs](https://www.home-assistant.io/integrations/broadlink/)).
+
 ```yaml
 smartir:
-
-switch:
-  - platform: broadlink
-    host: 192.168.10.10
-    mac: '00:00:00:00:00:00'
-    type: rm4_mini
 
 media_player:
   - platform: smartir
     name: Living room TV
     unique_id: living_room_tv
     device_code: 1000
-    controller_data: 192.168.10.10
+    controller_data: remote.bedroom_remote
     power_sensor: binary_sensor.tv_power
 ```
 


### PR DESCRIPTION
Broadlink devices are now configured via config flow and `broadlink.send` is deprecated in favor of `remote.send_command`.
This update is necessary to keep things working after [these changes](https://github.com/home-assistant/core/pull/36914).