### PR TITLE
Disable unneeded polling for climate and fan entities

### DIFF
--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -168,6 +168,11 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
                                      self._async_power_sensor_changed)
 
     @property
+    def should_poll(self):
+        """Entity does not implement async_update."""
+        return False
+
+    @property
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
@@ -287,7 +292,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         if not self._hvac_mode.lower() == HVAC_MODE_OFF:
             await self.send_command()
 
-        await self.async_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set operation mode."""
@@ -297,7 +302,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             self._last_on_operation = hvac_mode
 
         await self.send_command()
-        await self.async_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_set_fan_mode(self, fan_mode):
         """Set fan mode."""
@@ -305,7 +310,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         
         if not self._hvac_mode.lower() == HVAC_MODE_OFF:
             await self.send_command()      
-        await self.async_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_off(self):
         """Turn off."""
@@ -346,7 +351,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             return
 
         self._async_update_temp(new_state)
-        await self.async_update_ha_state()
+        self.async_write_ha_state()
 
     async def _async_humidity_sensor_changed(self, entity_id, old_state, new_state):
         """Handle humidity sensor changes."""
@@ -354,7 +359,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             return
 
         self._async_update_humidity(new_state)
-        await self.async_update_ha_state()
+        self.async_write_ha_state()
 
     async def _async_power_sensor_changed(self, entity_id, old_state, new_state):
         """Handle power sensor changes."""
@@ -363,13 +368,13 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
 
         if new_state.state == STATE_ON and self._hvac_mode == HVAC_MODE_OFF:
             self._on_by_remote = True
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
         if new_state.state == HVAC_MODE_OFF:
             self._on_by_remote = False
             if self._hvac_mode != HVAC_MODE_OFF:
                 self._hvac_mode = HVAC_MODE_OFF
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
     @callback
     def _async_update_temp(self, state):

--- a/custom_components/smartir/fan.py
+++ b/custom_components/smartir/fan.py
@@ -143,6 +143,11 @@ class SmartIRFan(FanEntity, RestoreEntity):
                                          self._async_power_sensor_changed)
 
     @property
+    def should_poll(self):
+        """Entity does not implement async_update."""
+        return False
+
+    @property
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
@@ -210,14 +215,14 @@ class SmartIRFan(FanEntity, RestoreEntity):
             self._last_on_speed = speed
 
         await self.send_command()
-        await self.async_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation of the fan."""
         self._oscillating = oscillating
 
         await self.send_command()
-        await self.async_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_set_direction(self, direction: str):
         """Set the direction of the fan"""
@@ -226,7 +231,7 @@ class SmartIRFan(FanEntity, RestoreEntity):
         if not self._speed.lower() == SPEED_OFF:
             await self.send_command()
 
-        await self.async_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_on(self, speed: str = None, **kwargs):
         """Turn on the fan."""
@@ -266,10 +271,11 @@ class SmartIRFan(FanEntity, RestoreEntity):
         if new_state.state == STATE_ON and self._speed == SPEED_OFF:
             self._on_by_remote = True
             self._speed = None
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
         if new_state.state == STATE_OFF:
             self._on_by_remote = False
             if self._speed != SPEED_OFF:
                 self._speed = SPEED_OFF
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
+


### PR DESCRIPTION
Since these entities do not implement async_update, there
is no need to poll

Additionally state can be written directly without the need
to call `async_update_ha_state` by calling `async_write_ha_state`
which avoids the slow entity update check.