### PR TITLE
Add support for SMC SP486 & SP483 Ceiling Fan

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "[markdown]": {
+        "editor.formatOnSave": false
+    },
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "[markdown]": {
-        "editor.formatOnSave": false
-    },
-}

--- a/codes/fan/1140.json
+++ b/codes/fan/1140.json
@@ -1,0 +1,21 @@
+{
+    "manufacturer": "SMC",
+    "supportedModels": [
+      "SP486", "SP483"
+    ],
+    "supportedController": "Broadlink",
+    "commandsEncoding": "Base64",
+    "speed": [
+      "low",
+      "medium",
+      "high"
+    ],
+    "commands": {
+      "off": "JgBOACoNKg4OKg4pDioOKQ4pKg8NKg4pDykOAAEHKw0qDg4pDykOKQ8pDioqDQ8oDykOKg4AAQgqDSoNDykOKg4pDioOKSoODioOKQ8oDwANBQAAAAAAAAAAAAA=",
+      "default": {
+        "low": "JgBKACwMKg4OKQ8oDyksDA4pDykOKQ8pKg4s6iwLKg0PKQ8pDygrDQ8oDikPKg4pKwwr6ysMKw4PKA4pDyksCw8pDioOKQ8oKw0sAA0FAAAAAAAAAAAAAAAAAAA=",
+        "medium": "JgBOACsNKg0PKQ4qDikPKA8pDioOKSoODikPAAEHKg4pDg8pDikPKA8qDikPKA8pKg4OKg4AAQcqDioNDikPKQ8pDikPKQ4pDioqDg4pDgANBQAAAAAAAAAAAAA=",
+        "high": "JgBKACsNKg0PKQ4pDioOKg4pDikPKQ4qDikq7CoNKg4OKg4pDioOKQ8oDyoOKQ8oDykq6ysOKwwPKQ4pDikPKQ8pDikPKQ4pDiorAA0FAAAAAAAAAAAAAAAAAAA="
+      }
+    }
+  }

--- a/docs/FAN.md
+++ b/docs/FAN.md
@@ -143,3 +143,8 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 | Code | Supported Models | Controller |
 | ------------- | -------------------------- | ------------- |
 [1120](../codes/fan/1120.json)|Unknown|Broadlink
+
+#### SMC
+| Code | Supported Models | Controller |
+| ------------- | -------------------------- | ------------- |
+[1140](../codes/fan/1140.json)|SP486, SP483|Broadlink


### PR DESCRIPTION
Added support for the SP486 and SP483 Ceiling Fan by SMC. Also added a `settings.json` for [VSCode](https://code.visualstudio.com/) users to prevent formatting of the Markdown files (in my case the formatting of the tables in `docs/FAN.md` was changed by '[Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one#github-flavored-markdown)').