### PR TITLE
Fix malformed JSON in Climate 1125.json

### DIFF
--- a/codes/climate/1125.json
+++ b/codes/climate/1125.json
@@ -1,3 +1,4 @@
+{
   "manufacturer": "Mitsubishi Electric",
   "supportedModels": [
     "MLZ-KP25VF",


### PR DESCRIPTION
was missing the opening brace