### PR TITLE
Fix malformed JSON in Climate 1126.json

### DIFF
--- a/codes/climate/1126.json
+++ b/codes/climate/1126.json
@@ -1,8 +1,8 @@
 {
   "manufacturer": "Mitsubishi Electric",
   "supportedModels": [
-    "MSX09-NV II"
-    "MSH-07RV"
+    "MSX09-NV II",
+    "MSH-07RV",
     "MSH-12RV"
   ],
   "commandsEncoding": "Base64",


### PR DESCRIPTION
It was missing the commas for the supportedModels array