### PR TITLE
Update CLIMATE.md

### DIFF
--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -654,3 +654,8 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 | Code                               | Supported Models       | Controller |
 | ---------------------------------- | ---------------------- | ---------- |
 | [2640](../codes/climate/2640.json) | FPR-91DE4-R<br>FPR-121DE4-R<br>FPR-141DE4-R | Broadlink  |
+
+#### Aire+
+| Code                               | Supported Models | Controller |
+| ---------------------------------- | ---------------- | ---------- |
+| [1522](../codes/climate/1522.json) | DG11L1-04        | Broadlink  |


### PR DESCRIPTION
Added "Aire+" , which is a white label of "Hisense" sold in Europe. The DG11L1-04 remote is, from quick testing I just completed, compatible with the 1522 code file, so it's the one linked.

Alternatively, the Hisense entry could be tweaked to include this remote, but it will not be as straightforward for someone looking for compatibility, since you need to know Hisense is the main brand, which is not common knowledge.