### PR TITLE
esphome: add option to use other encodings apart from `raw`

### DIFF
--- a/codes/media_player/1044.json
+++ b/codes/media_player/1044.json
@@ -1,0 +1,33 @@
+{
+  "manufacturer": "LG",
+  "supportedModels": ["55UH8509"],
+  "supportedController": "ESPHome",
+  "commandsEncoding": "DataNbits",
+  "commands": {
+    "on": { "data": "20DF23DC", "nbits": 32 },
+    "off": { "data": "20DFA35C", "nbits": 32 },
+    "volumeDown": { "data": "20DFC03F", "nbits": 32 },
+    "volumeUp": { "data": "20DF40BF", "nbits": 32 },
+    "mute": { "data": "20DF906F", "nbits": 32 },
+    "previousChannel": { "data": "20DF807F", "nbits": 32 },
+    "nextChannel": { "data": "20DF00FF", "nbits": 32 },
+    "0": { "data": "20DF08F7", "nbits": 32 },
+    "1": { "data": "20DF8877", "nbits": 32 },
+    "2": { "data": "20DF48B7", "nbits": 32 },
+    "3": { "data": "20DFC837", "nbits": 32 },
+    "4": { "data": "20DF28D7", "nbits": 32 },
+    "5": { "data": "20DFA857", "nbits": 32 },
+    "6": { "data": "20DF6897", "nbits": 32 },
+    "7": { "data": "20DFE817", "nbits": 32 },
+    "8": { "data": "20DF18E7", "nbits": 32 },
+    "9": { "data": "20DF9867", "nbits": 32 },
+    "sources": {
+      "HDMI1": { "data": "20DF738C", "nbits": 32 },
+      "HDMI2": { "data": "20DF33CC", "nbits": 32 },
+      "HDMI3": { "data": "20DF9768", "nbits": 32 },
+      "USB": { "data": "20DF3EC1", "nbits": 32 },
+      "LiveTV": { "data": "20DF42BD", "nbits": 32 },
+      "AV": { "data": "20DF5AA5", "nbits": 32 }
+    }
+  }
+}

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -74,7 +74,7 @@ media_player:
 ```
 
 ## Example (using ESPHome):
-ESPHome configuration example:
+### ESPHome configuration example:
 ```yaml
 esphome:
   name: my_espir
@@ -94,7 +94,56 @@ remote_transmitter:
   pin: GPIO14
   carrier_duty_percent: 50%
 ```
-HA configuration.yaml:
+Additionally to `raw` codes, brand specific encoders can also be used with the corresponding encodings in the json file.
+
+The ESPHome service should be changed to the matching `remote_transmitter.transmit_<brand>`
+with the appropriate parameters.
+
+Encoding: `Data` (for JVC, Samsung)
+```yaml
+api:
+  services:
+    - service: send_jvc_command
+      variables:
+        data: int
+      then:
+        - remote_transmitter.transmit_jvc:
+            data: !lambda 'return data;'
+```
+In the `json` codes' file, commands must be a plain integer or a string in hex.
+
+
+Encoding: `DataNbits` (for LG, Sony)
+```yaml
+api:
+  services:
+    - service: send_lg_command
+      variables:
+        data: int
+        nbits: int
+      then:
+        - remote_transmitter.transmit_lg:
+            data: !lambda 'return data;'
+            nbits: !lambda 'return nbits;'
+```
+In the `json` codes' file, commands must be an object with `data` and optionally `nbits` properties. `data` must be a plain integer or a string in hex.
+
+Encoding: `AddressCommand` (for NEC, RC5, Samsung36, Panasonic).
+```yaml
+api:
+  services:
+    - service: send_nec_command
+      variables:
+        address: int
+        command: int
+      then:
+        - remote_transmitter.transmit_nec:
+            address: !lambda 'return data;'
+            command: !lambda 'return nbits;'
+```
+In the `json` codes' file, commands must be an object with `address` and  `command` properties. Both must be plain integers or strings in hex.
+
+### HA configuration.yaml:
 ```yaml
 smartir:
 
@@ -107,7 +156,7 @@ media_player:
     power_sensor: binary_sensor.tv_power
 ```
 
-### Overriding Source Names
+## Overriding Source Names
 Source names in device files are usually set to the name that the media player uses. These often aren't very descriptive, so you can override these names in the configuration file. You can also remove a source by setting its name to `null`.
 
 ```yaml
@@ -144,6 +193,7 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 [1041](../codes/media_player/1041.json)|LH6235D|Broadlink
 [1042](../codes/media_player/1042.json)|43UM7510PSB<br>OLED55B8SSC|Broadlink
 [1043](../codes/media_player/1043.json)|32LC2R|Broadlink
+[1044](../codes/media_player/1044.json)|55UH8509|ESPHome
 
 #### Samsung
 | Code | Supported Models | Controller |


### PR DESCRIPTION
Raw encoding is very general, but not very practical, as they are not available in most online IR code datasheets.
Allow to use other encoders according to the parameters of the service:
- 'Data': for JVC, Samsung
- 'DataNbits' for LG, Sony
- 'AddressCommand': for NEC, RC5, Samsung36, Panasonic.

Add examples for media_player and codes for a LG TV.