### PR TITLE
Added automatic conversions between Celsius and Fahrenheit.

### DIFF
--- a/codes/climate/1000.json
+++ b/codes/climate/1000.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/1020.json
+++ b/codes/climate/1020.json
@@ -9,6 +9,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1021.json
+++ b/codes/climate/1021.json
@@ -8,6 +8,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1022.json
+++ b/codes/climate/1022.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 0.5,

--- a/codes/climate/1023.json
+++ b/codes/climate/1023.json
@@ -7,6 +7,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1024.json
+++ b/codes/climate/1024.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1025.json
+++ b/codes/climate/1025.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit": "celsius",
   "minTemperature":18.0,
   "maxTemperature":25.0,
   "precision":1.0,

--- a/codes/climate/1026.json
+++ b/codes/climate/1026.json
@@ -5,6 +5,7 @@
     ],
     "supportedController": "Broadlink",
     "commandsEncoding": "Base64",
+    "temperatureUnit": "celsius",
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,

--- a/codes/climate/1027.json
+++ b/codes/climate/1027.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1028.json
+++ b/codes/climate/1028.json
@@ -6,6 +6,7 @@
     ],
     "supportedController":"Broadlink",
     "commandsEncoding":"Base64",
+    "temperatureUnit":"celsius",
     "minTemperature":16.0,
     "maxTemperature":30.0,
     "precision":1.0,

--- a/codes/climate/1029.json
+++ b/codes/climate/1029.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,

--- a/codes/climate/1030.json
+++ b/codes/climate/1030.json
@@ -5,6 +5,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+   "temperatureUnit":"celsius",
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,

--- a/codes/climate/1040.json
+++ b/codes/climate/1040.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,

--- a/codes/climate/1041.json
+++ b/codes/climate/1041.json
@@ -11,6 +11,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1042.json
+++ b/codes/climate/1042.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1043.json
+++ b/codes/climate/1043.json
@@ -5,6 +5,7 @@
     ],
     "supportedController": "Broadlink",
     "commandsEncoding": "Base64",
+    "temperatureUnit": "celsius",
     "minTemperature": 18.0,
     "maxTemperature": 30.0,
     "precision": 1.0,

--- a/codes/climate/1044.json
+++ b/codes/climate/1044.json
@@ -5,6 +5,7 @@
     ],
     "supportedController": "Broadlink",
     "commandsEncoding": "Base64",
+    "temperatureUnit": "fahrenheit",
     "minTemperature": 61.0,
     "maxTemperature": 86.0,
     "precision": 1.0,

--- a/codes/climate/1060.json
+++ b/codes/climate/1060.json
@@ -7,6 +7,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1061.json
+++ b/codes/climate/1061.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1062.json
+++ b/codes/climate/1062.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 18.0,
     "maxTemperature": 30.0,
     "precision": 1.0,

--- a/codes/climate/1063.json
+++ b/codes/climate/1063.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1064.json
+++ b/codes/climate/1064.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1065.json
+++ b/codes/climate/1065.json
@@ -8,6 +8,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,

--- a/codes/climate/1066.json
+++ b/codes/climate/1066.json
@@ -8,6 +8,7 @@
    ],
    "commandsEncoding":"Base64",
    "supportedController":"Broadlink",
+   "temperatureUnit":"celsius",
    "minTemperature":18,
    "maxTemperature":30,
    "precision":1,

--- a/codes/climate/1067.json
+++ b/codes/climate/1067.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1068.json
+++ b/codes/climate/1068.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1069.json
+++ b/codes/climate/1069.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1080.json
+++ b/codes/climate/1080.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1081.json
+++ b/codes/climate/1081.json
@@ -9,6 +9,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,

--- a/codes/climate/1082.json
+++ b/codes/climate/1082.json
@@ -6,6 +6,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,

--- a/codes/climate/1083.json
+++ b/codes/climate/1083.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":32,
   "precision":1,

--- a/codes/climate/1084.json
+++ b/codes/climate/1084.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1.0,

--- a/codes/climate/1100.json
+++ b/codes/climate/1100.json
@@ -8,6 +8,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1101.json
+++ b/codes/climate/1101.json
@@ -15,6 +15,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1102.json
+++ b/codes/climate/1102.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1103.json
+++ b/codes/climate/1103.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,

--- a/codes/climate/1104.json
+++ b/codes/climate/1104.json
@@ -3,6 +3,7 @@
     "supportedModels": ["TF25DVM"],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 18,
     "maxTemperature": 32,
     "precision": 1,

--- a/codes/climate/1105.json
+++ b/codes/climate/1105.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "fahrenheit",
     "minTemperature": 64,
     "maxTemperature": 86,
     "precision": 1,

--- a/codes/climate/1106.json
+++ b/codes/climate/1106.json
@@ -7,6 +7,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1107.json
+++ b/codes/climate/1107.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1108.json
+++ b/codes/climate/1108.json
@@ -7,6 +7,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 18,
     "maxTemperature": 32,
     "precision": 1,

--- a/codes/climate/1109.json
+++ b/codes/climate/1109.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,

--- a/codes/climate/1110.json
+++ b/codes/climate/1110.json
@@ -8,6 +8,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 32.0,
   "precision": 1.0,

--- a/codes/climate/1111.json
+++ b/codes/climate/1111.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 20,
     "maxTemperature": 30,
     "precision": 1,

--- a/codes/climate/1112.json
+++ b/codes/climate/1112.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":18,
   "maxTemperature":32,
   "precision":1,

--- a/codes/climate/1113.json
+++ b/codes/climate/1113.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1120.json
+++ b/codes/climate/1120.json
@@ -11,6 +11,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1121.json
+++ b/codes/climate/1121.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,

--- a/codes/climate/1122.json
+++ b/codes/climate/1122.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 10,
   "maxTemperature": 31,
   "precision": 1,

--- a/codes/climate/1123.json
+++ b/codes/climate/1123.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 26.0,
   "precision": 1.0,

--- a/codes/climate/1124.json
+++ b/codes/climate/1124.json
@@ -10,6 +10,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,

--- a/codes/climate/1125.json
+++ b/codes/climate/1125.json
@@ -7,6 +7,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,

--- a/codes/climate/1126.json
+++ b/codes/climate/1126.json
@@ -7,6 +7,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,

--- a/codes/climate/1127.json
+++ b/codes/climate/1127.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,

--- a/codes/climate/1128.json
+++ b/codes/climate/1128.json
@@ -6,6 +6,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,

--- a/codes/climate/1129.json
+++ b/codes/climate/1129.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,

--- a/codes/climate/1130.json
+++ b/codes/climate/1130.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,

--- a/codes/climate/1131.json
+++ b/codes/climate/1131.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit":"celsius",
   "minTemperature": 19.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1132.json
+++ b/codes/climate/1132.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,

--- a/codes/climate/1140.json
+++ b/codes/climate/1140.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1160.json
+++ b/codes/climate/1160.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1161.json
+++ b/codes/climate/1161.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/1162.json
+++ b/codes/climate/1162.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":17,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/1180.json
+++ b/codes/climate/1180.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1181.json
+++ b/codes/climate/1181.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1182.json
+++ b/codes/climate/1182.json
@@ -3,6 +3,7 @@
   "supportedModels": ["GMV-R45G/NaB-K"],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1183.json
+++ b/codes/climate/1183.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1184.json
+++ b/codes/climate/1184.json
@@ -6,6 +6,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+   "temperatureUnit":"celsius",
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,

--- a/codes/climate/1200.json
+++ b/codes/climate/1200.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1220.json
+++ b/codes/climate/1220.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "fahrenheit",
   "minTemperature": 62.0,
   "maxTemperature": 86.0,
   "precision": 1.0,

--- a/codes/climate/1240.json
+++ b/codes/climate/1240.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1241.json
+++ b/codes/climate/1241.json
@@ -6,6 +6,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+   "temperatureUnit":"celsius",
    "minTemperature":18.0,
    "maxTemperature":32.0,
    "precision":1.0,

--- a/codes/climate/1260.json
+++ b/codes/climate/1260.json
@@ -8,6 +8,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1261.json
+++ b/codes/climate/1261.json
@@ -6,6 +6,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1262.json
+++ b/codes/climate/1262.json
@@ -8,6 +8,7 @@
    ],
    "commandsEncoding":"Base64",
    "supportedController":"Broadlink",
+   "temperatureUnit":"fahrenheit",
    "minTemperature":62,
    "maxTemperature":86,
    "precision":1,

--- a/codes/climate/1280.json
+++ b/codes/climate/1280.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1281.json
+++ b/codes/climate/1281.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 29.0,
   "precision": 1.0,

--- a/codes/climate/1282.json
+++ b/codes/climate/1282.json
@@ -5,6 +5,7 @@
     ],
     "supportedController": "Broadlink",
     "commandsEncoding": "Base64",
+    "temperatureUnit": "celsius",
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,

--- a/codes/climate/1283.json
+++ b/codes/climate/1283.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1284.json
+++ b/codes/climate/1284.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1285.json
+++ b/codes/climate/1285.json
@@ -5,6 +5,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+   "temperatureUnit":"celsius",
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,

--- a/codes/climate/1286.json
+++ b/codes/climate/1286.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":18,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/1287.json
+++ b/codes/climate/1287.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1288.json
+++ b/codes/climate/1288.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1289.json
+++ b/codes/climate/1289.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1290.json
+++ b/codes/climate/1290.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/1300.json
+++ b/codes/climate/1300.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 32.0,
   "precision": 1.0,

--- a/codes/climate/1320.json
+++ b/codes/climate/1320.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1321.json
+++ b/codes/climate/1321.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1340.json
+++ b/codes/climate/1340.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1341.json
+++ b/codes/climate/1341.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 18,
   "maxTemperature": 32,
   "precision": 1,

--- a/codes/climate/1342.json
+++ b/codes/climate/1342.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1343.json
+++ b/codes/climate/1343.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1360.json
+++ b/codes/climate/1360.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1380.json
+++ b/codes/climate/1380.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1381.json
+++ b/codes/climate/1381.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 28.0,
   "precision": 1.0,

--- a/codes/climate/1382.json
+++ b/codes/climate/1382.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1383.json
+++ b/codes/climate/1383.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1384.json
+++ b/codes/climate/1384.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 25.0,
   "precision": 1.0,

--- a/codes/climate/1385.json
+++ b/codes/climate/1385.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 17,
     "maxTemperature": 30,
     "precision": 1,

--- a/codes/climate/1386.json
+++ b/codes/climate/1386.json
@@ -5,6 +5,7 @@
    ],
    "commandsEncoding":"Base64",
    "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
    "minTemperature":17,
    "maxTemperature":30,
    "precision":1,

--- a/codes/climate/1400.json
+++ b/codes/climate/1400.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1401.json
+++ b/codes/climate/1401.json
@@ -5,6 +5,7 @@
     ],
     "supportedController": "Broadlink",
     "commandsEncoding": "Base64",
+    "temperatureUnit": "celsius",
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,

--- a/codes/climate/1420.json
+++ b/codes/climate/1420.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,

--- a/codes/climate/1440.json
+++ b/codes/climate/1440.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,

--- a/codes/climate/1460.json
+++ b/codes/climate/1460.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1480.json
+++ b/codes/climate/1480.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1481.json
+++ b/codes/climate/1481.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1500.json
+++ b/codes/climate/1500.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1501.json
+++ b/codes/climate/1501.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1520.json
+++ b/codes/climate/1520.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1521.json
+++ b/codes/climate/1521.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 32.0,
   "precision": 1.0,

--- a/codes/climate/1522.json
+++ b/codes/climate/1522.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1540.json
+++ b/codes/climate/1540.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1560.json
+++ b/codes/climate/1560.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1580.json
+++ b/codes/climate/1580.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1600.json
+++ b/codes/climate/1600.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,

--- a/codes/climate/1601.json
+++ b/codes/climate/1601.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1620.json
+++ b/codes/climate/1620.json
@@ -14,6 +14,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1621.json
+++ b/codes/climate/1621.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1640.json
+++ b/codes/climate/1640.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1660.json
+++ b/codes/climate/1660.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":17,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/1661.json
+++ b/codes/climate/1661.json
@@ -5,6 +5,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
    "minTemperature":16,
    "maxTemperature":31,
    "precision":1,

--- a/codes/climate/1680.json
+++ b/codes/climate/1680.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1681.json
+++ b/codes/climate/1681.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1682.json
+++ b/codes/climate/1682.json
@@ -6,6 +6,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1683.json
+++ b/codes/climate/1683.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1684.json
+++ b/codes/climate/1684.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1685.json
+++ b/codes/climate/1685.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1686.json
+++ b/codes/climate/1686.json
@@ -8,6 +8,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 18,
     "maxTemperature": 30,
     "precision": 1,

--- a/codes/climate/1687.json
+++ b/codes/climate/1687.json
@@ -6,6 +6,7 @@
     ],
     "supportedController": "Broadlink",
     "commandsEncoding": "Base64",
+    "temperatureUnit": "celsius",
     "minTemperature": 18.0,
     "maxTemperature": 30.0,
     "precision": 1.0,

--- a/codes/climate/1688.json
+++ b/codes/climate/1688.json
@@ -7,6 +7,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1700.json
+++ b/codes/climate/1700.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1701.json
+++ b/codes/climate/1701.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding":"Base64",
     "supportedController":"Broadlink",
+    "temperatureUnit":"celsius",
     "minTemperature":16,
     "maxTemperature":30,
     "precision":1,

--- a/codes/climate/1702.json
+++ b/codes/climate/1702.json
@@ -20,6 +20,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1720.json
+++ b/codes/climate/1720.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,

--- a/codes/climate/1740.json
+++ b/codes/climate/1740.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1760.json
+++ b/codes/climate/1760.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 17,
     "maxTemperature": 30,
     "precision": 1,

--- a/codes/climate/1761.json
+++ b/codes/climate/1761.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,

--- a/codes/climate/1762.json
+++ b/codes/climate/1762.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,

--- a/codes/climate/1763.json
+++ b/codes/climate/1763.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/1780.json
+++ b/codes/climate/1780.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/1781.json
+++ b/codes/climate/1781.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 16,
     "maxTemperature": 30,
     "precision": 1,

--- a/codes/climate/1800.json
+++ b/codes/climate/1800.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,

--- a/codes/climate/1820.json
+++ b/codes/climate/1820.json
@@ -6,6 +6,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":32,
   "precision":1,

--- a/codes/climate/1840.json
+++ b/codes/climate/1840.json
@@ -6,6 +6,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,

--- a/codes/climate/1860.json
+++ b/codes/climate/1860.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,

--- a/codes/climate/1880.json
+++ b/codes/climate/1880.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1900.json
+++ b/codes/climate/1900.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16.0,
   "maxTemperature":31.0,
   "precision":1.0,

--- a/codes/climate/1920.json
+++ b/codes/climate/1920.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1940.json
+++ b/codes/climate/1940.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1941.json
+++ b/codes/climate/1941.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/1942.json
+++ b/codes/climate/1942.json
@@ -5,6 +5,7 @@
     ],
     "supportedController": "Broadlink",
     "commandsEncoding": "Base64",
+    "temperatureUnit": "celsius",
     "minTemperature": 16,
     "maxTemperature": 32,
     "precision": 1,

--- a/codes/climate/1943.json
+++ b/codes/climate/1943.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1944.json
+++ b/codes/climate/1944.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":17.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1960.json
+++ b/codes/climate/1960.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/1980.json
+++ b/codes/climate/1980.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/2000.json
+++ b/codes/climate/2000.json
@@ -6,6 +6,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/2020.json
+++ b/codes/climate/2020.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/2040.json
+++ b/codes/climate/2040.json
@@ -8,6 +8,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "fahrenheit",
   "minTemperature": 62,
   "maxTemperature": 86,
   "precision": 1,

--- a/codes/climate/2060.json
+++ b/codes/climate/2060.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 13.0,
     "maxTemperature": 32.0,
     "precision": 1.0,

--- a/codes/climate/2080.json
+++ b/codes/climate/2080.json
@@ -5,6 +5,7 @@
    ],
    "commandsEncoding":"Base64",
    "supportedController":"Broadlink",
+   "temperatureUnit":"celsius",
    "minTemperature":16,
    "maxTemperature":32,
    "precision":1,

--- a/codes/climate/2100.json
+++ b/codes/climate/2100.json
@@ -5,6 +5,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+   "temperatureUnit":"celsius",
    "minTemperature":17,
    "maxTemperature":30,
    "precision":1,

--- a/codes/climate/2120.json
+++ b/codes/climate/2120.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 10,
   "maxTemperature": 32,
   "precision": 1,

--- a/codes/climate/2140.json
+++ b/codes/climate/2140.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 20,
   "maxTemperature": 28,
   "precision": 1,

--- a/codes/climate/2160.json
+++ b/codes/climate/2160.json
@@ -6,6 +6,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+   "temperatureUnit":"celsius",
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1,

--- a/codes/climate/2161.json
+++ b/codes/climate/2161.json
@@ -5,6 +5,7 @@
    ],
    "supportedController": "Broadlink",
    "commandsEncoding": "Base64",
+   "temperatureUnit": "celsius",
    "minTemperature": 17.0,
    "maxTemperature": 30.0,
    "precision": 1,

--- a/codes/climate/2180.json
+++ b/codes/climate/2180.json
@@ -5,6 +5,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+   "temperatureUnit":"celsius",
    "minTemperature":16,
    "maxTemperature":30,
    "precision":1,

--- a/codes/climate/2200.json
+++ b/codes/climate/2200.json
@@ -3,6 +3,7 @@
   "supportedModels": ["RAK-12NH", "RAK-18NH"],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/2220.json
+++ b/codes/climate/2220.json
@@ -6,6 +6,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "fahrenheit",
     "minTemperature": 62,
     "maxTemperature": 82,
     "precision": 1,

--- a/codes/climate/2240.json
+++ b/codes/climate/2240.json
@@ -6,6 +6,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 16,
     "maxTemperature": 32,
     "precision": 1,

--- a/codes/climate/2260.json
+++ b/codes/climate/2260.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,

--- a/codes/climate/2280.json
+++ b/codes/climate/2280.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 16,
     "maxTemperature": 25,
     "precision": 1,

--- a/codes/climate/2281.json
+++ b/codes/climate/2281.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 16,
     "maxTemperature": 31,
     "precision": 1,

--- a/codes/climate/2300.json
+++ b/codes/climate/2300.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/2301.json
+++ b/codes/climate/2301.json
@@ -6,6 +6,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/2320.json
+++ b/codes/climate/2320.json
@@ -9,6 +9,7 @@
    ],
    "commandsEncoding":"Base64",
    "supportedController":"Broadlink",
+   "temperatureUnit": "fahrenheit",
    "minTemperature":62,
    "maxTemperature":88,
    "precision":2,

--- a/codes/climate/2340.json
+++ b/codes/climate/2340.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/2360.json
+++ b/codes/climate/2360.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/2380.json
+++ b/codes/climate/2380.json
@@ -5,6 +5,7 @@
     ],
     "supportedController":"Broadlink",
     "commandsEncoding":"Base64",
+    "temperatureUnit":"celsius",
     "minTemperature":16.0,
     "maxTemperature":32.0,
     "precision":0.5,

--- a/codes/climate/2400.json
+++ b/codes/climate/2400.json
@@ -6,6 +6,7 @@
 	],
 	"commandsEncoding": "Base64",
 	"supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
 	"minTemperature": 16,
 	"maxTemperature": 31,
 	"precision": 1,

--- a/codes/climate/2420.json
+++ b/codes/climate/2420.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,

--- a/codes/climate/2440.json
+++ b/codes/climate/2440.json
@@ -5,6 +5,7 @@
 	],
 	"supportedController": "Broadlink",
 	"commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
 	"minTemperature": 16,
 	"maxTemperature": 30,
 	"precision": 1,

--- a/codes/climate/2460.json
+++ b/codes/climate/2460.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding": "Base64",
     "supportedController": "Broadlink",
+    "temperatureUnit": "celsius",
     "minTemperature": 16.0,
     "maxTemperature": 32.0,
     "precision": 1.0,

--- a/codes/climate/2480.json
+++ b/codes/climate/2480.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/2500.json
+++ b/codes/climate/2500.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":32.0,
   "precision":1.0,

--- a/codes/climate/2520.json
+++ b/codes/climate/2520.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding":"Base64",
     "supportedController":"Broadlink",
+    "temperatureUnit":"celsius",
     "minTemperature":16,
     "maxTemperature":31,
     "precision":1,

--- a/codes/climate/2540.json
+++ b/codes/climate/2540.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/2560.json
+++ b/codes/climate/2560.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",
+  "temperatureUnit":"celsius",
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/2580.json
+++ b/codes/climate/2580.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":16.0,
   "maxTemperature":32.0,
   "precision":0.5,

--- a/codes/climate/2600.json
+++ b/codes/climate/2600.json
@@ -5,6 +5,7 @@
    ],
    "commandsEncoding":"Base64",
    "supportedController":"Broadlink",
+   "temperatureUnit":"celsius",
    "minTemperature":16,
    "maxTemperature":30,
    "precision":1,

--- a/codes/climate/2620.json
+++ b/codes/climate/2620.json
@@ -5,6 +5,7 @@
   ],
   "supportedController":"Broadlink",
   "commandsEncoding":"Base64",
+  "temperatureUnit":"celsius",
   "minTemperature":17,
   "maxTemperature":30,
   "precision":1,

--- a/codes/climate/2640.json
+++ b/codes/climate/2640.json
@@ -7,6 +7,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+   "temperatureUnit":"celsius",
    "minTemperature":17.0,
    "maxTemperature":30.0,
    "precision":1.0,

--- a/codes/climate/2660.json
+++ b/codes/climate/2660.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
+  "temperatureUnit": "celsius",
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/2680.json
+++ b/codes/climate/2680.json
@@ -5,6 +5,7 @@
   ],
   "commandsEncoding": "Base64",
   "supportedController": "Broadlink",
+  "temperatureUnit": "celsius",
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,

--- a/codes/climate/2700.json
+++ b/codes/climate/2700.json
@@ -18,6 +18,7 @@
    ],
    "commandsEncoding":"Base64",
    "supportedController":"Broadlink",
+   "temperatureUnit": "celsius",
    "minTemperature":25,
    "maxTemperature":31,
    "precision":1,

--- a/codes/climate/2720.json
+++ b/codes/climate/2720.json
@@ -5,6 +5,7 @@
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",
+   "temperatureUnit":"celsius",
    "minTemperature":16,
    "maxTemperature":32,
    "precision":1,

--- a/codes/climate/3060.json
+++ b/codes/climate/3060.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Xiaomi",
   "commandsEncoding": "Raw",
+  "temperatureUnit":"celsius",
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,

--- a/codes/climate/3100.json
+++ b/codes/climate/3100.json
@@ -8,6 +8,7 @@
   ],
   "supportedController": "Xiaomi",
   "commandsEncoding": "Raw",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/3129.json
+++ b/codes/climate/3129.json
@@ -5,6 +5,7 @@
     ],
     "supportedController":"Xiaomi",
     "commandsEncoding":"Raw",
+    "temperatureUnit":"celsius",
     "minTemperature":18.0,
     "maxTemperature":30.0,
     "precision":1.0,

--- a/codes/climate/3180.json
+++ b/codes/climate/3180.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Xiaomi",
   "commandsEncoding": "Raw",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/3181.json
+++ b/codes/climate/3181.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Xiaomi",
   "commandsEncoding": "Raw",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/3285.json
+++ b/codes/climate/3285.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Xiaomi",
   "commandsEncoding": "Raw",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/3380.json
+++ b/codes/climate/3380.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Xiaomi",
   "commandsEncoding": "Raw",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/3580.json
+++ b/codes/climate/3580.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "Xiaomi",
   "commandsEncoding": "Raw",
+  "temperatureUnit": "celsius",
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/5520.json
+++ b/codes/climate/5520.json
@@ -5,6 +5,7 @@
     ],
     "commandsEncoding":"Raw",
     "supportedController":"LOOKin",
+    "temperatureUnit":"celsius",
     "minTemperature":16,
     "maxTemperature":30,
     "precision":1,

--- a/codes/climate/7260.json
+++ b/codes/climate/7260.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "ESPHome",
   "commandsEncoding": "Raw",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/7285.json
+++ b/codes/climate/7285.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "ESPHome",
   "commandsEncoding": "Raw",
+  "temperatureUnit": "celsius",
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,

--- a/codes/climate/7386.json
+++ b/codes/climate/7386.json
@@ -5,6 +5,7 @@
     ],
     "supportedController": "ESPHome",
     "commandsEncoding": "Raw",
+    "temperatureUnit": "celsius",
     "minTemperature": 17.0,
     "maxTemperature": 30.0,
     "precision": 1.0,

--- a/codes/climate/7740.json
+++ b/codes/climate/7740.json
@@ -5,6 +5,7 @@
   ],
   "supportedController": "ESPHome",
   "commandsEncoding": "Raw",
+  "temperatureUnit": "celsius",
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,


### PR DESCRIPTION
As reported in #669, #160, #155, and #29, SmartIR climate devices export min, max, and target temperature values in the temperature units used to define the device codes, even though HA expects those values to be in the HA instance's units. This produces buggy-looking output such as this:

<img width="406" alt="smartir" src="https://user-images.githubusercontent.com/1678448/125178277-28c1cc00-e198-11eb-9c24-620b03c2884e.png">

Note how the current temperature is 77F while the target temperature is 22F.

Although this can be worked around by creating a separate copy of the device codes with all of the values converted to Fahrenheit, that is cumbersome.

This PR proposes storing the target temperature in the HA instance's native units, and converting, rounding, and constraining it only when mapping to IR codes.

To guarantee the correct conversion, device JSON can now specify a `temperatureUnit` to indicate whether the values are in 'celsius' or 'fahrenheit', and every existing device JSON now defines `temperatureUnit`. However, the setting is optional; if missing it can reliably be detected based on the temperature range.