### PR TITLE
MediaPlayer: wait until device is ready after turning on or off

### DIFF
--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -234,7 +234,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         """Turn the media player on."""
 
         if self._warm_up_delay > 0:
-            self._warmed_up_at = time.monotonic + self._warmed_up_delay
+            self._warmed_up_at = time.monotonic() + self._warm_up_delay
 
         await self.send_command(self._commands['on'], wait_for_warm_up=False)
 
@@ -294,7 +294,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         async with self._temp_lock:
 
             if wait_for_warm_up:
-                wait_for_warm_up()
+                await self.wait_for_warm_up()
 
             try:
                 await self._controller.send(command)
@@ -303,7 +303,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
     async def wait_for_warm_up(self):
         if self._warmed_up_at:
-            time_to_wait = self._warmed_up_at - time.monotonic
+            time_to_wait = self._warmed_up_at - time.monotonic()
             if time_to_wait > 0:
                 await asyncio.sleep(time_to_wait)
 

--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -91,7 +91,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         self._name = config.get(CONF_NAME)
         self._device_code = config.get(CONF_DEVICE_CODE)
         self._controller_data = config.get(CONF_CONTROLLER_DATA)
-        self._delay = config.get(CONF_DELAY)
+        self._delay = float(config.get(CONF_DELAY))
         self._power_sensor = config.get(CONF_POWER_SENSOR)
 
         self._manufacturer = device_data['manufacturer']
@@ -297,8 +297,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
             except Exception as e:
                 _LOGGER.exception(e)
                 return
-            if init_time:
-                self._ready_at = time.monotonic() + init_time
+            self._ready_at = time.monotonic() + max(init_time or 0, self._delay)
 
     async def wait_until_ready(self):
         if self._ready_at:


### PR DESCRIPTION
When turning on some devices it takes some time before the device is ready to the next ir commands. Same goes for turning off the device. 

With the current implementation scripting something like "turn on receiver and set input to hdmi2" requires adding a delay to the script between the two commands.

This PR adds two new device parameters: `warm_up_delay` and `cool_down_delay` that fixes this.

Another change is that `delay` is respected always and not only when sending command lists. 
BTW: why is `delay`set in the HA config.yaml instead of in the device descriptor files?