### PR TITLE
Update compatibility model for existing code 1112

### DIFF
--- a/codes/climate/1112.json
+++ b/codes/climate/1112.json
@@ -1,7 +1,8 @@
 {
   "manufacturer":"Daikin",
   "supportedModels":[
-    "ATKC09TV2S"
+    "ATKC09TV2S",
+    "FTKQ12TV2S"
   ],
   "commandsEncoding":"Base64",
   "supportedController":"Broadlink",

--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -191,7 +191,7 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 | [1109](../codes/climate/1109.json) | BRC4C158 (Remote)                                                                                                                                              | Broadlink  |
 | [1110](../codes/climate/1110.json) | FTC15NV14<br>FTC20NV14<br>FTC25NV14<br>FTC35NV14                                                                                                                                              | Broadlink  |
 | [1111](../codes/climate/1111.json) | FTE09NV25                                                                                                                                           | Broadlink  |
-| [1112](../codes/climate/1112.json) | ATKC09TV2S                                                                                                                                           | Broadlink  |
+| [1112](../codes/climate/1112.json) | ATKC09TV2S<br>FTKQ12TV2S                                                                                                                                           | Broadlink  |
 | [1113](../codes/climate/1113.json) | FTXV35AV1B                                                                                                                                           | Broadlink  |
 | [3100](../codes/climate/3100.json) | FTXS25CVMB<br>FTXS35CVMB<br>FTXS60BVMB<br>FVXS25BVMB                                                                                                           | Xiaomi     |
 


### PR DESCRIPTION
The existing code 1112 also work with FTKQ12TV2S model.

This code should work with any FTKQ*TV2S model which included 
- FTKQ09TV2S
- FTKQ12TV2S 
- FTKQ15TV2S 
- FTKQ18TV2S 
- FTKQ24TV2S  