### PR TITLE
Add support for fans that transmit oscillation state and speed in a single command

### DIFF
--- a/custom_components/smartir/fan.py
+++ b/custom_components/smartir/fan.py
@@ -254,7 +254,10 @@ class SmartIRFan(FanEntity, RestoreEntity):
             if speed.lower() == SPEED_OFF:
                 command = self._commands['off']
             elif oscillating:
-                command = self._commands['oscillate']
+                if isinstance(self._commands['oscillate'], dict):
+                    command = self._commands['oscillate'][speed]
+                else:
+                    command = self._commands['oscillate']
             else:
                 command = self._commands[direction][speed] 
 


### PR DESCRIPTION
Seville Classics (and other manufacturer's) fans use an "All at Once Remote" where the entirety of the state is stored in the remote and transmitted to the fan at every transmission. This includes the power, speed and the oscillation state.

To allow this fan's oscillations to be controlled, a change was needed in the structure of the command JSON file. This allows for storing a list of commands with oscillation enabled and a list of commands with oscillation disabled (default). This change is backwards compatible using the existing `oscillate` command in the JSON. If the command is a single command, it is transmitted as is, otherwise the appropriate speed is looked up in that array and transmitted. This is similar to how the `reverse` speeds are stored in the schema ([example](https://github.com/smartHomeHub/SmartIR/blob/master/codes/fan/1000.json)).

An example set of codes (from the Seville Classics Slimline Tower Fan):

```json
{
  "manufacturer": "Seville Classics",
  "supportedModels": [
    "Unknown"
  ],
  "supportedController": "Broadlink",
  "commandsEncoding": "Base64",
  "speed": [
    "eco",
    "low",
    "medium",
    "high"
  ],
  "commands": {
    "off": "JgCIAAABQZ8SExITEhMSNxITEhMSExITEhMSExI3EhMSExITEhMSExITEhMSNxI3EhMSExITEjcSExI3EhMSExITEhMSNxI3EhMSNxITEjcSExITEhMSExITEhMSExITEhMSExITEhMSExI3EjcRFBITEhMSExITEhMSNxI2EzYSExMSEjcSExIADQUAAAAAAAAAAAAAAAAAAA==",
    "default": {
      "eco": "JgCIAAABN58SExITEhMSNxITEhMSExI3EhMSExI3EhMSExITEhMSExITEhMSNxI3ExMSExITEhMSExI2ExMSExITEhMSNhM3EhMSNxIUETcTExITEhMSExITEhMSExITEhMSFBITEhMSExI3EzcSFBEUERQRFBEUERQRNxI3EzcSExITEjcSFBIADQU=",
      "low": "JgCIAAABMqASExEUERQROBITERQSFBA5EhMRFBE4EhMSExITEhMSExITEhQQOBI3EhMSExITEhMSExE4EhMSFBEUERQRExIUERQSNhMSEjcSExITEhQRExIUERMSFBITEhQSExISEhQSExI2EzcSExITEhMSExITEhMSNxI3EjgSExITEhMSNxMADQU=",
      "medium": "JgCIAAABNKESExEUERYPOBEVEBQQFRE4ERQRFRA4ERQRFRAUERQQFREUERQROBE5ERQQFREUERQQFg85ERQRFBAVEBURFBA5ERQROBEUEDkQFRAWDxUQFRAVEBUQFRAWDxURFg8VEBUQFg86EDoRFBAVEBUQFRAVEBUQORA5EDoPFg8WDxYQFRAADQU=",
      "high": "JgCIAAABNJ8TEhMTEhMSNhMTEhMSExI2ExMSExI2ExMSExITEhMSExITEhMSNhU0ExMSExITEhMSExI2ExMSExITEhMSNxITEhQROBEUETgSExITEhQRExITEhMSExITEhMSFBITEhMSExI4EjcSExIVEBMSExITEhMUNRI4EjgRExIUETgSNxIADQU="
    },
    "oscillate": {
      "eco": "JgCIAAABOZ8RFRAVERQSNxEVEBUQFRA5ERQRFBE4ERQRFBEUERQRFBITERQSNxE4ERQRFBEUETgRFBE4ERURFBEUERQROBE5ERQROBEUETkRFBEUERQRFBEUERQRFBEUERQSFBEUERQSExI3ETgRFRAVEBUQFRAVERQQORE4ETkRFBEUETgROREADQUAAAAAAAAAAAAAAAAAAA==",
      "low": "JgCIAAABMaARFBEVERQROBEUERQRFBE4ERQRFRA5ERQRFBEUEBUQFREUERQROBE4ERQRFBEUETgTEw86ERQQFREUEBURFBAVERQROBEUEDkRFBEUEBUQFREUERQRFBEUERQRFBEUERQRFBE4ETgRFBEUERQRFBEUERUQOBE4ETkQFRAVEBUQFRAADQUAAAAAAAAAAAAAAAAAAA==",
      "medium": "JgCIAAABMaEQFREUERQROBEUERQRFBE4ERQRFBE4EhQQFREUERQRFBEUERQROBE4ERQRFBEUETkRFBE4ERQRFBEUERQRFBE4EBUROA0YEDkRFBEUERQRFRAVERQRFBEUERQRFBAVEBURFRE4ETkRFBEUERQRFBEUERQROBE4ETgSFBEUEBUQOREADQUAAAAAAAAAAAAAAAAAAA==",
      "high": "JgCIAAABMZ8RFREUERQROREUEBURFBA5ERQSExE3ERURFBEUERQRFBEUERQRORA5ERQRFBEUEDkRFBE4ERQRFBEUERQROBEUERQROBEVEDkRFBEUERQRFBEUERQRFBEUERQRFBEUERUQFRE5EDkRFBEUERQRFBEUERQSNxE4ETkRFBEUETgRFRAADQUAAAAAAAAAAAAAAAAAAA=="	
    }
  }
}
```

This closes #532.

I will add my json file as a separate PR after this one is accepted.