### PR TITLE
Update fan 1080.json and add 1081.json

### DIFF
--- a/codes/fan/1080.json
+++ b/codes/fan/1080.json
@@ -1,7 +1,7 @@
 {
-  "manufacturer": "Hamilton Bay",
+  "manufacturer": "Harbor Breeze",
   "supportedModels": [
-    "Unknown"
+    "A25-TX001-R1"
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",

--- a/codes/fan/1081.json
+++ b/codes/fan/1081.json
@@ -23,6 +23,6 @@
       "5": "eAs0ABAaDxoPGg8aDxkPGRAaDxoPGg8aDxoPGg8aDxoPGg8aEBoPDRwaEA0bDRwaDw0bGg8AAbkAAAAA",
       "6": "eAs0ABAaDxoPGg8aDxoPGg8aDxoPGg8aDxoPGg8aDxoPGg8aEA0bGg8aDw0bDRsaDw0bGg8AAbkAAAAA"
     },
-    "Oscillate": "eQs0AA8aDhsPGw4bDhsOGg4bDxsPGw4bDhsOGw4bDhsOGw4bDxsOGw4bDg8bDhobDw4aGw4AAboAAAAA"
+    "oscillate": "eQs0AA8aDhsPGw4bDhsOGg4bDxsPGw4bDhsOGw4bDhsOGw4bDxsOGw4bDg8bDhobDw4aGw4AAboAAAAA"
   }
 }

--- a/codes/fan/1081.json
+++ b/codes/fan/1081.json
@@ -1,0 +1,28 @@
+{
+  "manufacturer": "Harbor Breeze",
+  "supportedModels": [
+    "A25-TX025"
+  ],
+  "supportedController": "Broadlink",
+  "commandsEncoding": "Base64",
+  "speed": [
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6"
+  ],
+  "commands": {
+    "off": "eAs0ABARHx0QHRAdEB0QDx8eEB0QDx8dEA8fHRAdEB0RDh8PHw8fDh8OHx0QDx8dEA8fHQ8AAYEA",
+    "default": {
+      "1": "eAc0ABAaDxoPGg8aDxoPGg8aDxoPGg8aDxoPGg8aDxoPGg8aEBoPDhsOGw0bDRsaDw4bGg8AAbkAAAAA",
+      "2": "eAY0ABAaDxoPGg8aDxoPGg8aDxoPGg8aDxoPGg8aDxoPGg8aEA0bGg8OGw4bDhsaDw0bGg8AAbkAAAAA",
+      "3": "eAs0AA8aDhsPGg8aDxsPGg8aDxoPGg8aDxsPGg8aDxsPGg8bDxoPGg8OGw4bDhsbDw4bGg8AAboAAAAA",
+      "4": "eAc0ABAZEBoPGg8ZEBoPGQ8aEBkQGQ8ZDxoQGQ8ZEBkPGg8aEA0cDRwZEA0cDRwZEA0cGQ8AAbkAAAAA",
+      "5": "eAs0ABAaDxoPGg8aDxkPGRAaDxoPGg8aDxoPGg8aDxoPGg8aEBoPDRwaEA0bDRwaDw0bGg8AAbkAAAAA",
+      "6": "eAs0ABAaDxoPGg8aDxoPGg8aDxoPGg8aDxoPGg8aDxoPGg8aEA0bGg8aDw0bDRsaDw0bGg8AAbkAAAAA"
+    },
+    "Oscillate": "eQs0AA8aDhsPGw4bDhsOGg4bDxsPGw4bDhsOGw4bDhsOGw4bDxsOGw4bDg8bDhobDw4aGw4AAboAAAAA"
+  }
+}

--- a/docs/FAN.md
+++ b/docs/FAN.md
@@ -130,10 +130,11 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 | ------------- | -------------------------- | ------------- |
 [1060](../codes/fan/1060.json)|A1|Broadlink
 
-#### Hampton Bay
+#### Harbor Breeze
 | Code | Supported Models | Controller |
 | ------------- | -------------------------- | ------------- |
-[1080](../codes/fan/1080.json)|Unknown|Broadlink
+[1080](../codes/fan/1080.json)|A25-TX001-R1|Broadlink
+[1081](../codes/fan/1081.json)|A25-TX025|Broadlink
 
 #### Pacific
 | Code | Supported Models | Controller |


### PR DESCRIPTION
My original issue incorrectly listed Hamilton Bay as the fan manufacturer while it should have been Harbor Breeze (Lowe's in-house brand)

I also added the supported model as the FCC ID of the remote.

https://github.com/smartHomeHub/SmartIR/issues/256

I also added in 1081.json, which is another fan from same manufacturer but with a different RF remote / receiver unit. "Breeze" mode is implemented as oscillate, as it is a toggleable mode.

Documentation was also updated as well.