### PR TITLE
Updated to include Toshiba RAS-M10SKV-E in 1260 compatibility

### DIFF
--- a/codes/climate/1260.json
+++ b/codes/climate/1260.json
@@ -4,7 +4,8 @@
     "RAS-13NKV-E / RAS-13NAV-E",
     "RAS-13NKV-A / RAS-13NAV-A",
     "RAS-16NKV-E / RAS-16NAV-E",
-    "RAS-16NKV-A / RAS-16NAV-A"
+    "RAS-16NKV-A / RAS-16NAV-A",
+    "RAS-M10SKV-E"
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",

--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -259,7 +259,7 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 #### Toshiba
 | Code                               | Supported Models                                                                                                 | Controller |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------- |
-| [1260](../codes/climate/1260.json) | RAS-13NKV-E / RAS-13NAV-E<br>RAS-13NKV-A / RAS-13NAV-A<br>RAS-16NKV-E / RAS-16NAV-E<br>RAS-16NKV-A / RAS-16NAV-A | Broadlink  |
+| [1260](../codes/climate/1260.json) | RAS-13NKV-E / RAS-13NAV-E<br>RAS-13NKV-A / RAS-13NAV-A<br>RAS-16NKV-E / RAS-16NAV-E<br>RAS-16NKV-A / RAS-16NAV-A<br>RAS-M10SKV-E | Broadlink  |
 | [1261](../codes/climate/1261.json) | WH-TA05NE<br>WH-TA11EJ                                                                                           | Broadlink  |
 | [1262](../codes/climate/1262.json) | RAC-PD0812CRRU<br>RAC-PD1013CWRU<br>RAC-PD1213CWRU<br>RAC-PD1414CWRU                                             | Broadlink  |
 | [1263](../codes/climate/1263.json) | RAS-B07J2KVSG-E<br>RAS-B10J2KVSG-E<br>RAS-B13J2KVSG-E                                                            | Broadlink  |


### PR DESCRIPTION
Confirmed codes in 1260.json work with Toshiba RAS-M10SKV-E heat pump