### PR TITLE
Add support for imperial units to climate entity

### DIFF
--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -300,7 +300,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
     
     @staticmethod
     def _fahrenheit_to_celsius(self, temperature):
-        retrun round((temperature - 32) * 5 / 9)
+        return round((temperature - 32) * 5 / 9)
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""

--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -119,10 +119,6 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         self._fan_modes = device_data['fanModes']
         self._swing_modes = device_data.get('swingModes')
         self._commands = device_data['commands']
-        
-        if self._unit == TEMP_FAHRENHEIT:
-            self._min_temperature = self._celsius_to_fahrenheit(self._min_temperature)
-            self._max_temperature = self._celsius_to_fahrenheit(self._max_temperature)
 
         self._target_temperature = self._min_temperature
         self._hvac_mode = HVAC_MODE_OFF
@@ -134,6 +130,10 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         self._current_humidity = None
 
         self._unit = hass.config.units.temperature_unit
+        
+        if self._unit == TEMP_FAHRENHEIT:
+            self._min_temperature = self._celsius_to_fahrenheit(self._min_temperature)
+            self._max_temperature = self._celsius_to_fahrenheit(self._max_temperature)
         
         #Supported features
         self._support_flags = SUPPORT_FLAGS
@@ -293,12 +293,10 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             'supported_controller': self._supported_controller,
             'commands_encoding': self._commands_encoding
         }
-    
-    @staticmethod
+
     def _celsius_to_fahrenheit(self, temperature):
         return round(temperature * 9 / 5) + 32
-    
-    @staticmethod
+
     def _fahrenheit_to_celsius(self, temperature):
         return round((temperature - 32) * 5 / 9)
 


### PR DESCRIPTION
This adds support for Fahrenheit handling to the climate entity, so now the current temperature from the temperature sensor will properly match the target temperature within the climate display in terms of units.

This closes #686 