### PR TITLE
Update media_player.py

### DIFF
--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -281,6 +281,8 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         self._source = "Channel {}".format(media_id)
         for digit in media_id:
             await self.send_command(self._commands['sources']["Channel {}".format(digit)])
+        if 'OK' in self._commands['sources'] is not None:
+            await self.send_command(self._commands['sources']['OK'])
         await self.async_update_ha_state()
 
     async def send_command(self, command):


### PR DESCRIPTION
If on the TV to turn on a two-digit (three-digit) channel, you must first press the "..." button, activating the ability to turn on two-digit (three-digit) channels, then to turn on the one-digit channel, you must press the "OK" button after the "..." button. On TVs where pressing the "..." button is not necessary, completing the channel command with the "OK" button will only speed up the switching.