### PR TITLE
Adds a sound mode selector

### DIFF
--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -10,7 +10,8 @@ from homeassistant.components.media_player import (
 from homeassistant.components.media_player.const import (
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_PREVIOUS_TRACK,
     SUPPORT_NEXT_TRACK, SUPPORT_VOLUME_STEP, SUPPORT_VOLUME_MUTE, 
-    SUPPORT_PLAY_MEDIA, SUPPORT_SELECT_SOURCE, MEDIA_TYPE_CHANNEL)
+    SUPPORT_PLAY_MEDIA, SUPPORT_SELECT_SOURCE, MEDIA_TYPE_CHANNEL,
+    SUPPORT_SELECT_SOUND_MODE)
 from homeassistant.const import (
     CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
@@ -29,6 +30,7 @@ CONF_DEVICE_CODE = 'device_code'
 CONF_CONTROLLER_DATA = "controller_data"
 CONF_DELAY = "delay"
 CONF_POWER_SENSOR = 'power_sensor'
+CONF_SOUND_MODES = 'sound_modes'
 CONF_SOURCE_NAMES = 'source_names'
 CONF_DEVICE_CLASS = 'device_class'
 
@@ -39,6 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_CONTROLLER_DATA): cv.string,
     vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): cv.string,
     vol.Optional(CONF_POWER_SENSOR): cv.entity_id,
+    vol.Optional(CONF_SOUND_MODES): dict,
     vol.Optional(CONF_SOURCE_NAMES): dict,
     vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): cv.string
 })
@@ -100,6 +103,8 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         self._commands = device_data['commands']
 
         self._state = STATE_OFF
+        self._sound_mode_list = []
+        self._sound_mode = None
         self._sources_list = []
         self._source = None
         self._support_flags = 0
@@ -126,6 +131,19 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         if 'mute' in self._commands and self._commands['mute'] is not None:
             self._support_flags = self._support_flags | SUPPORT_VOLUME_MUTE
 
+        if 'sound_modes' in self._commands and self._commands['sound_modes'] is not None:
+            
+            for sound_mode, new_name in config.get(CONF_SOUND_MODES, {}).items():
+                if sound_mode in self._commands['sound_modes']:
+                    if new_name is not None:
+                        self._commands['sound_modes'][new_name] = self._commands['sound_modes'][sound_mode]
+
+                    del self._commands['sound_modes'][sound_mode]
+            
+            # Sound Modes list
+            for key in self._commands['sound_modes']:
+                self._sound_mode_list.append(key)
+        
         if 'sources' in self._commands and self._commands['sources'] is not None:
             self._support_flags = self._support_flags | SUPPORT_SELECT_SOURCE | SUPPORT_PLAY_MEDIA
 
@@ -158,6 +176,9 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
         if last_state is not None:
             self._state = last_state.state
+        
+        if self._sound_mode_list and self._state == STATE_ON:
+            self._support_flags |= SUPPORT_SELECT_SOUND_MODE
 
     @property
     def should_poll(self):
@@ -195,6 +216,14 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         return MEDIA_TYPE_CHANNEL
 
     @property
+    def sound_mode_list(self):
+        return self._sound_mode_list
+
+    @property
+    def sound_mode(self):
+        return self._sound_mode
+
+    @property
     def source_list(self):
         return self._sources_list
         
@@ -224,7 +253,10 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         
         if self._power_sensor is None:
             self._state = STATE_OFF
+            self._sound_mode = None
             self._source = None
+            if self._sound_mode_list:
+                self._support_flags ^= SUPPORT_SELECT_SOUND_MODE
             await self.async_update_ha_state()
 
     async def async_turn_on(self):
@@ -233,6 +265,8 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
         if self._power_sensor is None:
             self._state = STATE_ON
+            if self._sound_mode_list:
+                self._support_flags |= SUPPORT_SELECT_SOUND_MODE
             await self.async_update_ha_state()
 
     async def async_media_previous_track(self):
@@ -258,6 +292,12 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
     async def async_mute_volume(self, mute):
         """Mute the volume."""
         await self.send_command(self._commands['mute'])
+        await self.async_update_ha_state()
+
+    async def async_select_sound_mode(self, sound_mode: str):
+        """Select sound mode from list."""
+        self._sound_mode = sound_mode
+        await self.send_command(self._commands['sound_modes'][sound_mode])
         await self.async_update_ha_state()
 
     async def async_select_source(self, source):
@@ -299,6 +339,11 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         if power_state:
             if power_state.state == STATE_OFF:
                 self._state = STATE_OFF
+                self._sound_mode = None
                 self._source = None
+                if self._sound_mode_list:
+                    self._support_flags ^= SUPPORT_SELECT_SOUND_MODE
             elif power_state.state == STATE_ON:
                 self._state = STATE_ON
+                if self._sound_mode_list:
+                    self._support_flags |= SUPPORT_SELECT_SOUND_MODE

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -12,6 +12,7 @@ Find your device's brand code [here](MEDIA_PLAYER.md#available-codes-for-tv-devi
 **controller_data** (Required): The data required for the controller to function. Enter the IP address of the Broadlink device **(must be an already configured device)**, or the entity id of the Xiaomi IR controller, or the MQTT topic on which to send commands.<br />
 **delay** (Optional): Adjusts the delay in seconds between multiple commands. The default is 0.5 <br />
 **power_sensor** (Optional): *entity_id* for a sensor that monitors whether your device is actually On or Off. This may be a power monitor sensor. (Accepts only on/off states)<br />
+**sound_modes** (Optional): Override the names of sound modes as displayed in HomeAssistant (see below)<br />
 **source_names** (Optional): Override the names of sources as displayed in HomeAssistant (see below)<br />
 
 ## Example (using broadlink controller):
@@ -105,6 +106,22 @@ media_player:
     device_code: 2000
     controller_data: my_espir_send_raw_command
     power_sensor: binary_sensor.tv_power
+```
+
+### Overriding Sound Modes
+Sound modes in device files are usually set to the name that the media player uses. If they aren't very descriptive, so you can override these names in the configuration file. You can also remove a mode by setting its name to `null`.
+
+```yaml
+media_player:
+  - platform: smartir
+    name: Living room TV
+    unique_id: living_room_tv
+    device_code: 1000
+    controller_data: 192.168.10.10
+    sound_modes:
+      5.1: Home Theater
+      2.1: Speakers
+      TV: null
 ```
 
 ### Overriding Source Names


### PR DESCRIPTION
Adds a sound_mode list that will allow these modes to be controlled on audio systems and audio receivers until the media player is put into standby or turned off. Made by analogy with source_list, but with one caveat: by default, the GUI selector "Sound mode" does not disappear when the media player is turned off, so this feature is removed from supported_features every time it is turned off (because it is illogical to control the sound mode of a turned off device)