### PR TITLE
Saving the device state when shutting down and restarting Home Assistant (yaml setting)

### DIFF
--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -100,6 +100,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         self._commands = device_data['commands']
 
         self._state = STATE_OFF
+        self._is_volume_muted = None
         self._sources_list = []
         self._source = None
         self._support_flags = 0
@@ -136,7 +137,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
                     del self._commands['sources'][source]
 
-            #Sources list
+            # Sources list
             for key in self._commands['sources']:
                 self._sources_list.append(key)
 
@@ -195,6 +196,10 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         return MEDIA_TYPE_CHANNEL
 
     @property
+    def is_volume_muted(self):
+        return self._is_volume_muted
+
+    @property
     def source_list(self):
         return self._sources_list
         
@@ -225,6 +230,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         if self._power_sensor is None:
             self._state = STATE_OFF
             self._source = None
+            self._is_volume_muted = None
             await self.async_update_ha_state()
 
     async def async_turn_on(self):
@@ -257,6 +263,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
     
     async def async_mute_volume(self, mute):
         """Mute the volume."""
+        self._is_volume_muted = mute
         await self.send_command(self._commands['mute'])
         await self.async_update_ha_state()
 
@@ -300,5 +307,6 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
             if power_state.state == STATE_OFF:
                 self._state = STATE_OFF
                 self._source = None
+                self._is_volume_muted = None
             elif power_state.state == STATE_ON:
                 self._state = STATE_ON

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -13,6 +13,7 @@ Find your device's brand code [here](MEDIA_PLAYER.md#available-codes-for-tv-devi
 **delay** (Optional): Adjusts the delay in seconds between multiple commands. The default is 0.5 <br />
 **power_sensor** (Optional): *entity_id* for a sensor that monitors whether your device is actually On or Off. This may be a power monitor sensor. (Accepts only on/off states)<br />
 **source_names** (Optional): Override the names of sources as displayed in HomeAssistant (see below)<br />
+**retain** (Optional): The device to which this setting is applied, when turned on, will display the same settings that were set before turning it off. (see below)<br />
 
 ## Example (using broadlink controller):
 Add a Broadlink RM device named "Bedroom" via config flow (read the [docs](https://www.home-assistant.io/integrations/broadlink/)).
@@ -121,6 +122,22 @@ media_player:
       HDMI1: DVD Player
       HDMI2: Xbox
       VGA: null
+```
+
+### Retaining State
+Some (many) devices may retain the selected state after being turned off. This setting will allow you to remotely see what state the device is in: what signal source is selected, what sound mode and whether the sound is muted. But all this without feedback from the device. Three options are supported: `mute`, `sound_mode`, `source`. The device to which this setting is applied, when turned on, will display the same settings that were set before turning it off.
+
+```yaml
+media_player:
+  - platform: smartir
+    name: Living room TV
+    unique_id: living_room_tv
+    device_code: 1000
+    controller_data: 192.168.10.10
+    retain:
+        - mute
+        - source
+        - sound_mode
 ```
 
 ### Changing channels


### PR DESCRIPTION
Some (many) devices can save the selected state before turning off and restore it after turning on. This change will also allow you to remotely see what state the device is in: what signal source is selected, the sound mode, and whether the sound is muted. But all this without feedback from the device. On the other hand, the on / off state may also not have feedback. Therefore, for those who may need this function, they will have to configure their device in yaml