### PR TITLE
Adding delay between commands

### DIFF
--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -287,6 +287,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         async with self._temp_lock:
             try:
                 await self._controller.send(command)
+                await asyncio.sleep(int(self._delay))
             except Exception as e:
                 _LOGGER.exception(e)
             


### PR DESCRIPTION
For TV's thats can't get two commands to fast needs to create delay between them. For that reason in async function after sending command I added async delay.

I did this because my old LG TV can't change channel to two-digit number, cause IR controll spams it too fast.