### PR TITLE
Add unit for hard coded temperatures

### DIFF
--- a/codes/climate/1000.json
+++ b/codes/climate/1000.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1001.json
+++ b/codes/climate/1001.json
@@ -6,6 +6,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": ["cool", "heat", "dry", "fan_only"],
   "fanModes": ["auto", "low", "mid", "high"],
   "commands": {

--- a/codes/climate/1020.json
+++ b/codes/climate/1020.json
@@ -12,6 +12,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1021.json
+++ b/codes/climate/1021.json
@@ -11,6 +11,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1022.json
+++ b/codes/climate/1022.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 0.5,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1023.json
+++ b/codes/climate/1023.json
@@ -10,6 +10,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "heat",

--- a/codes/climate/1024.json
+++ b/codes/climate/1024.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1025.json
+++ b/codes/climate/1025.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":25.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat_cool",
     "heat",

--- a/codes/climate/1026.json
+++ b/codes/climate/1026.json
@@ -8,6 +8,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
       "heat_cool",
       "cool",

--- a/codes/climate/1027.json
+++ b/codes/climate/1027.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1028.json
+++ b/codes/climate/1028.json
@@ -9,6 +9,7 @@
     "minTemperature":16.0,
     "maxTemperature":30.0,
     "precision":1.0,
+    "unit": "°C",
     "operationModes":[
       "auto",
       "cool",

--- a/codes/climate/1029.json
+++ b/codes/climate/1029.json
@@ -8,6 +8,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat",

--- a/codes/climate/1030.json
+++ b/codes/climate/1030.json
@@ -8,6 +8,7 @@
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "heat_cool",
       "heat",

--- a/codes/climate/1031.json
+++ b/codes/climate/1031.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "heat",

--- a/codes/climate/1040.json
+++ b/codes/climate/1040.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1041.json
+++ b/codes/climate/1041.json
@@ -14,6 +14,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
 	"cool",

--- a/codes/climate/1042.json
+++ b/codes/climate/1042.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/1043.json
+++ b/codes/climate/1043.json
@@ -8,6 +8,7 @@
     "minTemperature": 18.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
       "heat_cool",
       "cool",

--- a/codes/climate/1044.json
+++ b/codes/climate/1044.json
@@ -8,6 +8,7 @@
     "minTemperature": 61.0,
     "maxTemperature": 86.0,
     "precision": 1.0,
+    "unit": "°F",
     "operationModes": [
       "auto",
       "cool",

--- a/codes/climate/1060.json
+++ b/codes/climate/1060.json
@@ -10,6 +10,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1061.json
+++ b/codes/climate/1061.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "ai",

--- a/codes/climate/1062.json
+++ b/codes/climate/1062.json
@@ -8,6 +8,7 @@
     "minTemperature": 18.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat",

--- a/codes/climate/1063.json
+++ b/codes/climate/1063.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "cool",

--- a/codes/climate/1064.json
+++ b/codes/climate/1064.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "dry"

--- a/codes/climate/1065.json
+++ b/codes/climate/1065.json
@@ -11,6 +11,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "auto",

--- a/codes/climate/1066.json
+++ b/codes/climate/1066.json
@@ -11,6 +11,7 @@
    "minTemperature":18,
    "maxTemperature":30,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "heat_cool",
       "cool",

--- a/codes/climate/1067.json
+++ b/codes/climate/1067.json
@@ -8,6 +8,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1068.json
+++ b/codes/climate/1068.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "ai",

--- a/codes/climate/1069.json
+++ b/codes/climate/1069.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1070.json
+++ b/codes/climate/1070.json
@@ -8,6 +8,7 @@
   "minTemperature":18,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1080.json
+++ b/codes/climate/1080.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "dry",

--- a/codes/climate/1081.json
+++ b/codes/climate/1081.json
@@ -12,6 +12,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1082.json
+++ b/codes/climate/1082.json
@@ -9,6 +9,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1083.json
+++ b/codes/climate/1083.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":32,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1084.json
+++ b/codes/climate/1084.json
@@ -9,6 +9,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "cool",

--- a/codes/climate/1085.json
+++ b/codes/climate/1085.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool"
   ],

--- a/codes/climate/1086.json
+++ b/codes/climate/1086.json
@@ -9,6 +9,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "dry",

--- a/codes/climate/1087.json
+++ b/codes/climate/1087.json
@@ -10,6 +10,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1088.json
+++ b/codes/climate/1088.json
@@ -10,6 +10,7 @@
 	"minTemperature": 16,
 	"maxTemperature": 32,
 	"precision": 1,
+	"unit": "°C",
 	"operationModes": [
 		"cool",
 		"heat",

--- a/codes/climate/1089.json
+++ b/codes/climate/1089.json
@@ -8,6 +8,7 @@
 	"minTemperature": 16.0,
 	"maxTemperature": 32.0,
 	"precision": 1.0,
+	"unit": "°C",
 	"operationModes": [
 	  "heat",
 	  "humidity",

--- a/codes/climate/1090.json
+++ b/codes/climate/1090.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "heat",

--- a/codes/climate/1100.json
+++ b/codes/climate/1100.json
@@ -11,6 +11,7 @@
     "minTemperature": 18,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "heat",
         "cool",

--- a/codes/climate/1101.json
+++ b/codes/climate/1101.json
@@ -24,6 +24,7 @@
    "minTemperature":18.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "heat_cool",
       "dry",

--- a/codes/climate/1102.json
+++ b/codes/climate/1102.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "dry",

--- a/codes/climate/1103.json
+++ b/codes/climate/1103.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool"
   ],

--- a/codes/climate/1104.json
+++ b/codes/climate/1104.json
@@ -6,6 +6,7 @@
     "minTemperature": 18,
     "maxTemperature": 32,
     "precision": 1,
+    "unit": "°C",
     "operationModes": ["cool", "dry", "fan_only"],
     "fanModes": ["auto", "nature", "level1", "level2", "level3", "level4", "level5"],
     "commands": {

--- a/codes/climate/1105.json
+++ b/codes/climate/1105.json
@@ -8,6 +8,7 @@
     "minTemperature": 64,
     "maxTemperature": 86,
     "precision": 1,
+    "unit": "°F",
     "operationModes": [
       "heat_cool",
       "dry",

--- a/codes/climate/1106.json
+++ b/codes/climate/1106.json
@@ -10,6 +10,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "dry",

--- a/codes/climate/1107.json
+++ b/codes/climate/1107.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "dry",

--- a/codes/climate/1108.json
+++ b/codes/climate/1108.json
@@ -10,6 +10,7 @@
     "minTemperature": 18,
     "maxTemperature": 32,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "auto",
         "dry",

--- a/codes/climate/1109.json
+++ b/codes/climate/1109.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "fan_only",
     "dry",

--- a/codes/climate/1110.json
+++ b/codes/climate/1110.json
@@ -11,6 +11,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "dry",

--- a/codes/climate/1111.json
+++ b/codes/climate/1111.json
@@ -8,6 +8,7 @@
     "minTemperature": 20,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "cool"
     ],

--- a/codes/climate/1112.json
+++ b/codes/climate/1112.json
@@ -9,6 +9,7 @@
   "minTemperature":18,
   "maxTemperature":32,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "dry",
     "cool",

--- a/codes/climate/1113.json
+++ b/codes/climate/1113.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1114.json
+++ b/codes/climate/1114.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "dry",

--- a/codes/climate/1115.json
+++ b/codes/climate/1115.json
@@ -8,6 +8,7 @@
   "minTemperature": 18,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "dry",

--- a/codes/climate/1116.json
+++ b/codes/climate/1116.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "fan_only"

--- a/codes/climate/1117.json
+++ b/codes/climate/1117.json
@@ -8,6 +8,7 @@
     "minTemperature": 10.0,
     "maxTemperature": 32.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "heat",
         "cool",

--- a/codes/climate/1118.json
+++ b/codes/climate/1118.json
@@ -13,6 +13,7 @@
   "minTemperature": 20.0,
   "maxTemperature": 26.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1119.json
+++ b/codes/climate/1119.json
@@ -8,6 +8,7 @@
     "minTemperature": 18.0,
     "maxTemperature": 24.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
       "cool",
       "fan_only",

--- a/codes/climate/1120.json
+++ b/codes/climate/1120.json
@@ -14,6 +14,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1121.json
+++ b/codes/climate/1121.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool"
   ],

--- a/codes/climate/1122.json
+++ b/codes/climate/1122.json
@@ -8,6 +8,7 @@
   "minTemperature": 10,
   "maxTemperature": 31,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1123.json
+++ b/codes/climate/1123.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 26.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
 	"heat"

--- a/codes/climate/1124.json
+++ b/codes/climate/1124.json
@@ -13,6 +13,7 @@
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/1125.json
+++ b/codes/climate/1125.json
@@ -10,6 +10,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1126.json
+++ b/codes/climate/1126.json
@@ -10,6 +10,7 @@
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "cool",

--- a/codes/climate/1127.json
+++ b/codes/climate/1127.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat"

--- a/codes/climate/1128.json
+++ b/codes/climate/1128.json
@@ -9,6 +9,7 @@
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1129.json
+++ b/codes/climate/1129.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/1130.json
+++ b/codes/climate/1130.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "dry",

--- a/codes/climate/1131.json
+++ b/codes/climate/1131.json
@@ -8,6 +8,7 @@
   "minTemperature": 19.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "dry",

--- a/codes/climate/1132.json
+++ b/codes/climate/1132.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "dry",

--- a/codes/climate/1133.json
+++ b/codes/climate/1133.json
@@ -11,6 +11,7 @@
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "ifeel",
     "cool",

--- a/codes/climate/1134.json
+++ b/codes/climate/1134.json
@@ -10,6 +10,7 @@
     "minTemperature": 16,
     "maxTemperature": 31,
     "precision": 1,
+    "unit": "°C",
     "operationModes": ["cool", "dry", "fan_only"],
     "fanModes": ["auto", "level1", "level2", "level3", "level4"],
     "commands": {

--- a/codes/climate/1135.json
+++ b/codes/climate/1135.json
@@ -10,6 +10,7 @@
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/1136.json
+++ b/codes/climate/1136.json
@@ -10,6 +10,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "dry",

--- a/codes/climate/1137.json
+++ b/codes/climate/1137.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 31,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat",

--- a/codes/climate/1138.json
+++ b/codes/climate/1138.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 31,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat",

--- a/codes/climate/1140.json
+++ b/codes/climate/1140.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1160.json
+++ b/codes/climate/1160.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1161.json
+++ b/codes/climate/1161.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "dry",

--- a/codes/climate/1162.json
+++ b/codes/climate/1162.json
@@ -8,6 +8,7 @@
   "minTemperature":17,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool"
   ],

--- a/codes/climate/1163.json
+++ b/codes/climate/1163.json
@@ -570,6 +570,7 @@
     "fan_only"
   ],
   "precision": 1,
+  "unit": "°F",
   "supportedController": "Broadlink",
   "supportedModels": [
     "40MAQB12B--3",

--- a/codes/climate/1164.json
+++ b/codes/climate/1164.json
@@ -8,6 +8,7 @@
     "minTemperature": 17,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "dry",

--- a/codes/climate/1180.json
+++ b/codes/climate/1180.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat_cool",
     "fan_only",

--- a/codes/climate/1181.json
+++ b/codes/climate/1181.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1182.json
+++ b/codes/climate/1182.json
@@ -6,6 +6,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": ["heat_cool", "fan_only", "dry", "cool", "heat"],
   "fanModes": ["low", "mid", "high", "auto"],
   "commands": {

--- a/codes/climate/1183.json
+++ b/codes/climate/1183.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1184.json
+++ b/codes/climate/1184.json
@@ -9,6 +9,7 @@
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "heat_cool",
       "fan_only",

--- a/codes/climate/1185.json
+++ b/codes/climate/1185.json
@@ -8,6 +8,7 @@
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "heat_cool",
       "cool",

--- a/codes/climate/1186.json
+++ b/codes/climate/1186.json
@@ -6,6 +6,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": ["heat", "cool"],
   "fanModes": ["low", "auto"],
   "commands": {

--- a/codes/climate/1187.json
+++ b/codes/climate/1187.json
@@ -6,6 +6,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": ["heat", "cool"],
   "fanModes": ["low", "auto"],
   "commands": {

--- a/codes/climate/1200.json
+++ b/codes/climate/1200.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1220.json
+++ b/codes/climate/1220.json
@@ -8,6 +8,7 @@
   "minTemperature": 62.0,
   "maxTemperature": 86.0,
   "precision": 1.0,
+  "unit": "°F",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1240.json
+++ b/codes/climate/1240.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1241.json
+++ b/codes/climate/1241.json
@@ -9,6 +9,7 @@
    "minTemperature":18.0,
    "maxTemperature":32.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "heat",
       "cool",

--- a/codes/climate/1260.json
+++ b/codes/climate/1260.json
@@ -12,6 +12,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1261.json
+++ b/codes/climate/1261.json
@@ -9,6 +9,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1262.json
+++ b/codes/climate/1262.json
@@ -11,6 +11,7 @@
    "minTemperature":62,
    "maxTemperature":86,
    "precision":1,
+   "unit": "°F",
    "operationModes":[
       "auto",
       "cool",

--- a/codes/climate/1263.json
+++ b/codes/climate/1263.json
@@ -11,6 +11,7 @@
    "minTemperature":17.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "heat",
       "cool",

--- a/codes/climate/1264.json
+++ b/codes/climate/1264.json
@@ -6,6 +6,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": ["cool", "heat", "dry", "auto", "fan"],
   "fanModes": ["auto", "level1", "level2", "level3", "level4", "level5"],
   "commands": {

--- a/codes/climate/1280.json
+++ b/codes/climate/1280.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1281.json
+++ b/codes/climate/1281.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 29.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1282.json
+++ b/codes/climate/1282.json
@@ -8,6 +8,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
       "heat",
       "cool",

--- a/codes/climate/1283.json
+++ b/codes/climate/1283.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "dry",

--- a/codes/climate/1284.json
+++ b/codes/climate/1284.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1285.json
+++ b/codes/climate/1285.json
@@ -8,6 +8,7 @@
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "heat",
       "cool",

--- a/codes/climate/1286.json
+++ b/codes/climate/1286.json
@@ -8,6 +8,7 @@
   "minTemperature":18,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1287.json
+++ b/codes/climate/1287.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1288.json
+++ b/codes/climate/1288.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1289.json
+++ b/codes/climate/1289.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1290.json
+++ b/codes/climate/1290.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1291.json
+++ b/codes/climate/1291.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1292.json
+++ b/codes/climate/1292.json
@@ -9,6 +9,7 @@
     "minTemperature": 18,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "heat_cool",
         "cool",

--- a/codes/climate/1293.json
+++ b/codes/climate/1293.json
@@ -10,6 +10,7 @@
     "minTemperature": 18,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "heat_cool",
         "cool",

--- a/codes/climate/1300.json
+++ b/codes/climate/1300.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1301.json
+++ b/codes/climate/1301.json
@@ -8,6 +8,7 @@
     "minTemperature":18.0,
     "maxTemperature":32.0,
     "precision":1.0,
+    "unit": "°C",
     "operationModes":[
         "cool",
         "heat",

--- a/codes/climate/1320.json
+++ b/codes/climate/1320.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1321.json
+++ b/codes/climate/1321.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1322.json
+++ b/codes/climate/1322.json
@@ -8,6 +8,7 @@
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "heat",

--- a/codes/climate/1340.json
+++ b/codes/climate/1340.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1341.json
+++ b/codes/climate/1341.json
@@ -8,6 +8,7 @@
   "minTemperature": 18,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1342.json
+++ b/codes/climate/1342.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1343.json
+++ b/codes/climate/1343.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1344.json
+++ b/codes/climate/1344.json
@@ -9,6 +9,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/1360.json
+++ b/codes/climate/1360.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1380.json
+++ b/codes/climate/1380.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1381.json
+++ b/codes/climate/1381.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 28.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1382.json
+++ b/codes/climate/1382.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1383.json
+++ b/codes/climate/1383.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "cool",

--- a/codes/climate/1384.json
+++ b/codes/climate/1384.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 25.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1385.json
+++ b/codes/climate/1385.json
@@ -8,6 +8,7 @@
     "minTemperature": 17,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "dry",

--- a/codes/climate/1386.json
+++ b/codes/climate/1386.json
@@ -8,6 +8,7 @@
    "minTemperature":17,
    "maxTemperature":30,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "heat"

--- a/codes/climate/1387.json
+++ b/codes/climate/1387.json
@@ -8,6 +8,7 @@
     "minTemperature": 17,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "auto",
         "cool",

--- a/codes/climate/1388.json
+++ b/codes/climate/1388.json
@@ -6,6 +6,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": ["heat", "cool", "dry", "auto"],
   "fanModes": ["auto"],
   "commands": {

--- a/codes/climate/1389.json
+++ b/codes/climate/1389.json
@@ -8,6 +8,7 @@
   "minTemperature": 62.0,
   "maxTemperature": 86.0,
   "precision": 1.0,
+  "unit": "°F",
   "operationModes": [
     "cool",
     "heat_cool",

--- a/codes/climate/1390.json
+++ b/codes/climate/1390.json
@@ -8,6 +8,7 @@
    "minTemperature":17,
    "maxTemperature":30,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "auto",
       "cool",

--- a/codes/climate/1391.json
+++ b/codes/climate/1391.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/1392.json
+++ b/codes/climate/1392.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/1393.json
+++ b/codes/climate/1393.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1400.json
+++ b/codes/climate/1400.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1401.json
+++ b/codes/climate/1401.json
@@ -8,6 +8,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat"

--- a/codes/climate/1402.json
+++ b/codes/climate/1402.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1403.json
+++ b/codes/climate/1403.json
@@ -8,6 +8,7 @@
    "minTemperature":18.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "heat_cool",
       "dry",

--- a/codes/climate/1404.json
+++ b/codes/climate/1404.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat",

--- a/codes/climate/1405.json
+++ b/codes/climate/1405.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/1406.json
+++ b/codes/climate/1406.json
@@ -8,6 +8,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
       "cool",
       "heat",

--- a/codes/climate/1420.json
+++ b/codes/climate/1420.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1440.json
+++ b/codes/climate/1440.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1441.json
+++ b/codes/climate/1441.json
@@ -14,6 +14,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1460.json
+++ b/codes/climate/1460.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1480.json
+++ b/codes/climate/1480.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "cool",

--- a/codes/climate/1481.json
+++ b/codes/climate/1481.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "heat_cool",

--- a/codes/climate/1500.json
+++ b/codes/climate/1500.json
@@ -8,6 +8,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1501.json
+++ b/codes/climate/1501.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "heat",

--- a/codes/climate/1520.json
+++ b/codes/climate/1520.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1521.json
+++ b/codes/climate/1521.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1522.json
+++ b/codes/climate/1522.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1540.json
+++ b/codes/climate/1540.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1560.json
+++ b/codes/climate/1560.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1580.json
+++ b/codes/climate/1580.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1581.json
+++ b/codes/climate/1581.json
@@ -8,6 +8,7 @@
    "minTemperature":16,
    "maxTemperature":32,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "heat",

--- a/codes/climate/1582.json
+++ b/codes/climate/1582.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1600.json
+++ b/codes/climate/1600.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1601.json
+++ b/codes/climate/1601.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1602.json
+++ b/codes/climate/1602.json
@@ -8,6 +8,7 @@
    "minTemperature":16.0,
    "maxTemperature":31.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "auto",
       "cool",

--- a/codes/climate/1603.json
+++ b/codes/climate/1603.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1620.json
+++ b/codes/climate/1620.json
@@ -17,6 +17,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1621.json
+++ b/codes/climate/1621.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1622.json
+++ b/codes/climate/1622.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1623.json
+++ b/codes/climate/1623.json
@@ -6,6 +6,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": ["heat", "cool"],
     "fanModes": ["low", "mid", "high"],
     "commands": {

--- a/codes/climate/1624.json
+++ b/codes/climate/1624.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1640.json
+++ b/codes/climate/1640.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1660.json
+++ b/codes/climate/1660.json
@@ -8,6 +8,7 @@
   "minTemperature":17,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1661.json
+++ b/codes/climate/1661.json
@@ -8,6 +8,7 @@
    "minTemperature":16,
    "maxTemperature":31,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "heat",
       "cool",

--- a/codes/climate/1680.json
+++ b/codes/climate/1680.json
@@ -9,6 +9,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1681.json
+++ b/codes/climate/1681.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1682.json
+++ b/codes/climate/1682.json
@@ -11,6 +11,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1683.json
+++ b/codes/climate/1683.json
@@ -8,6 +8,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1684.json
+++ b/codes/climate/1684.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool"

--- a/codes/climate/1685.json
+++ b/codes/climate/1685.json
@@ -8,6 +8,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "cool",

--- a/codes/climate/1686.json
+++ b/codes/climate/1686.json
@@ -11,6 +11,7 @@
     "minTemperature": 18,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
       "heat_cool",
       "cool",

--- a/codes/climate/1687.json
+++ b/codes/climate/1687.json
@@ -9,6 +9,7 @@
     "minTemperature": 18.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
       "cool",
       "heat",

--- a/codes/climate/1688.json
+++ b/codes/climate/1688.json
@@ -10,6 +10,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "cool",

--- a/codes/climate/1689.json
+++ b/codes/climate/1689.json
@@ -8,6 +8,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "cool",

--- a/codes/climate/1690.json
+++ b/codes/climate/1690.json
@@ -8,6 +8,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "cool",

--- a/codes/climate/1691.json
+++ b/codes/climate/1691.json
@@ -8,6 +8,7 @@
     "minTemperature": 18,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "auto",
         "cool",

--- a/codes/climate/1692.json
+++ b/codes/climate/1692.json
@@ -10,6 +10,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1700.json
+++ b/codes/climate/1700.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1701.json
+++ b/codes/climate/1701.json
@@ -8,6 +8,7 @@
     "minTemperature":16,
     "maxTemperature":30,
     "precision":1,
+    "unit": "°C",
     "operationModes":[  
        "cool",
        "heat",

--- a/codes/climate/1702.json
+++ b/codes/climate/1702.json
@@ -23,6 +23,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
   	"heat_cool",
     "cool",

--- a/codes/climate/1703.json
+++ b/codes/climate/1703.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "fan_only"

--- a/codes/climate/1704.json
+++ b/codes/climate/1704.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1720.json
+++ b/codes/climate/1720.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1740.json
+++ b/codes/climate/1740.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "heat",

--- a/codes/climate/1741.json
+++ b/codes/climate/1741.json
@@ -16,6 +16,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": ["heat_cool", "cool", "dry", "fan_only", "heat"],
   "fanModes": ["auto", "silent", "low", "mid", "high", "turbo"],
   "commands": {

--- a/codes/climate/1760.json
+++ b/codes/climate/1760.json
@@ -8,6 +8,7 @@
     "minTemperature": 17,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat",

--- a/codes/climate/1761.json
+++ b/codes/climate/1761.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1762.json
+++ b/codes/climate/1762.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1763.json
+++ b/codes/climate/1763.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1764.json
+++ b/codes/climate/1764.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1780.json
+++ b/codes/climate/1780.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "dry"

--- a/codes/climate/1781.json
+++ b/codes/climate/1781.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
       "cool",
       "dry",

--- a/codes/climate/1782.json
+++ b/codes/climate/1782.json
@@ -10,6 +10,7 @@
     "minTemperature": 17.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
       "cool",
       "dry",

--- a/codes/climate/1800.json
+++ b/codes/climate/1800.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1801.json
+++ b/codes/climate/1801.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/1820.json
+++ b/codes/climate/1820.json
@@ -9,6 +9,7 @@
   "minTemperature":16,
   "maxTemperature":32,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1840.json
+++ b/codes/climate/1840.json
@@ -9,6 +9,7 @@
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1860.json
+++ b/codes/climate/1860.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/1880.json
+++ b/codes/climate/1880.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/1900.json
+++ b/codes/climate/1900.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":31.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool"

--- a/codes/climate/1901.json
+++ b/codes/climate/1901.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":31.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1920.json
+++ b/codes/climate/1920.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1940.json
+++ b/codes/climate/1940.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1941.json
+++ b/codes/climate/1941.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/1942.json
+++ b/codes/climate/1942.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 32,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat",

--- a/codes/climate/1943.json
+++ b/codes/climate/1943.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1944.json
+++ b/codes/climate/1944.json
@@ -8,6 +8,7 @@
   "minTemperature":17.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat"

--- a/codes/climate/1945.json
+++ b/codes/climate/1945.json
@@ -8,6 +8,7 @@
   "minTemperature":22.0,
   "maxTemperature":27.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1946.json
+++ b/codes/climate/1946.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/1960.json
+++ b/codes/climate/1960.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/1962.json
+++ b/codes/climate/1962.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":32.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat_cool",
     "cool",

--- a/codes/climate/1980.json
+++ b/codes/climate/1980.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat"

--- a/codes/climate/2000.json
+++ b/codes/climate/2000.json
@@ -9,6 +9,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[  
       "cool",
       "heat",

--- a/codes/climate/2020.json
+++ b/codes/climate/2020.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/2040.json
+++ b/codes/climate/2040.json
@@ -11,6 +11,7 @@
   "minTemperature": 62,
   "maxTemperature": 86,
   "precision": 1,
+  "unit": "°F",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/2041.json
+++ b/codes/climate/2041.json
@@ -8,6 +8,7 @@
   "minTemperature": 61,
   "maxTemperature": 88,
   "precision": 1,
+  "unit": "°F",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/2060.json
+++ b/codes/climate/2060.json
@@ -8,6 +8,7 @@
     "minTemperature": 13.0,
     "maxTemperature": 32.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat",

--- a/codes/climate/2080.json
+++ b/codes/climate/2080.json
@@ -8,6 +8,7 @@
    "minTemperature":16,
    "maxTemperature":32,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "heat",

--- a/codes/climate/2100.json
+++ b/codes/climate/2100.json
@@ -8,6 +8,7 @@
    "minTemperature":17,
    "maxTemperature":30,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "cool"
    ],

--- a/codes/climate/2120.json
+++ b/codes/climate/2120.json
@@ -8,6 +8,7 @@
   "minTemperature": 10,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/2140.json
+++ b/codes/climate/2140.json
@@ -8,6 +8,7 @@
   "minTemperature": 20,
   "maxTemperature": 28,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat"

--- a/codes/climate/2160.json
+++ b/codes/climate/2160.json
@@ -9,6 +9,7 @@
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "heat_cool",

--- a/codes/climate/2161.json
+++ b/codes/climate/2161.json
@@ -8,6 +8,7 @@
    "minTemperature": 17.0,
    "maxTemperature": 30.0,
    "precision": 1,
+   "unit": "°C",
    "operationModes": [
       "heat_cool",
       "cool",

--- a/codes/climate/2162.json
+++ b/codes/climate/2162.json
@@ -9,6 +9,7 @@
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "heat_cool",
       "cool",

--- a/codes/climate/2180.json
+++ b/codes/climate/2180.json
@@ -8,6 +8,7 @@
    "minTemperature":16,
    "maxTemperature":30,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "heat",
       "cool"

--- a/codes/climate/2200.json
+++ b/codes/climate/2200.json
@@ -6,6 +6,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": ["cool", "heat", "dry", "fan_only"],
   "fanModes": ["auto", "high", "medium", "low"],
   "commands": {

--- a/codes/climate/2220.json
+++ b/codes/climate/2220.json
@@ -9,6 +9,7 @@
     "minTemperature": 62,
     "maxTemperature": 82,
     "precision": 1,
+    "unit": "°F",
     "operationModes": [
       "auto",
       "cool",

--- a/codes/climate/2240.json
+++ b/codes/climate/2240.json
@@ -9,6 +9,7 @@
     "minTemperature": 16,
     "maxTemperature": 32,
     "precision": 1,
+    "unit": "°C",
     "operationModes":[
       "cool",
       "dry",

--- a/codes/climate/2241.json
+++ b/codes/climate/2241.json
@@ -8,6 +8,7 @@
     "minTemperature": 18,
     "maxTemperature": 32,
     "precision": 1,
+    "unit": "°C",
     "operationModes":[
       "cool",
       "dry",

--- a/codes/climate/2242.json
+++ b/codes/climate/2242.json
@@ -8,6 +8,7 @@
    "minTemperature":13,
    "maxTemperature":32,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "dry",

--- a/codes/climate/2260.json
+++ b/codes/climate/2260.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":31,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "dry",

--- a/codes/climate/2280.json
+++ b/codes/climate/2280.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 25,
     "precision": 1,
+    "unit": "°C",
     "operationModes":[
       "cool",
       "dry",

--- a/codes/climate/2281.json
+++ b/codes/climate/2281.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 31,
     "precision": 1,
+    "unit": "°C",
     "operationModes":[
       "cool",
       "dry",

--- a/codes/climate/2300.json
+++ b/codes/climate/2300.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/2301.json
+++ b/codes/climate/2301.json
@@ -9,6 +9,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/2320.json
+++ b/codes/climate/2320.json
@@ -12,6 +12,7 @@
    "minTemperature":62,
    "maxTemperature":88,
    "precision":2,
+   "unit": "°F",
    "operationModes":[
       "cool",
       "dry",

--- a/codes/climate/2321.json
+++ b/codes/climate/2321.json
@@ -14,6 +14,7 @@
    "minTemperature":16,
    "maxTemperature":32,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "dry",

--- a/codes/climate/2340.json
+++ b/codes/climate/2340.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/2360.json
+++ b/codes/climate/2360.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "fan_only",

--- a/codes/climate/2400.json
+++ b/codes/climate/2400.json
@@ -9,6 +9,7 @@
 	"minTemperature": 16,
 	"maxTemperature": 31,
 	"precision": 1,
+	"unit": "°C",
 	"operationModes": [
 		"cool",
 		"heat",

--- a/codes/climate/2420.json
+++ b/codes/climate/2420.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/2440.json
+++ b/codes/climate/2440.json
@@ -8,6 +8,7 @@
 	"minTemperature": 16,
 	"maxTemperature": 30,
 	"precision": 1,
+	"unit": "°C",
 	"operationModes": [
 		"heat",
 		"cool",

--- a/codes/climate/2460.json
+++ b/codes/climate/2460.json
@@ -8,6 +8,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 32.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "heat",

--- a/codes/climate/2480.json
+++ b/codes/climate/2480.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/2500.json
+++ b/codes/climate/2500.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":32.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/2520.json
+++ b/codes/climate/2520.json
@@ -8,6 +8,7 @@
     "minTemperature":16,
     "maxTemperature":31,
     "precision":1,
+    "unit": "°C",
     "operationModes":[
       "cool",
       "dry",

--- a/codes/climate/2540.json
+++ b/codes/climate/2540.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "auto",
     "heat",

--- a/codes/climate/2560.json
+++ b/codes/climate/2560.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "dry",

--- a/codes/climate/2600.json
+++ b/codes/climate/2600.json
@@ -8,6 +8,7 @@
    "minTemperature":16,
    "maxTemperature":30,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "heat",

--- a/codes/climate/2620.json
+++ b/codes/climate/2620.json
@@ -8,6 +8,7 @@
   "minTemperature":17,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "heat_cool",
     "cool",

--- a/codes/climate/2640.json
+++ b/codes/climate/2640.json
@@ -10,6 +10,7 @@
    "minTemperature":17.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "heat",

--- a/codes/climate/2641.json
+++ b/codes/climate/2641.json
@@ -6,6 +6,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": ["cool", "heat", "dry", "fan_only", "auto"],
   "fanModes": ["lowest", "low", "mid", "high"],
   "commands": {

--- a/codes/climate/2660.json
+++ b/codes/climate/2660.json
@@ -8,6 +8,7 @@
   "minTemperature": 18,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/2680.json
+++ b/codes/climate/2680.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "dry"

--- a/codes/climate/2700.json
+++ b/codes/climate/2700.json
@@ -21,6 +21,7 @@
    "minTemperature":25,
    "maxTemperature":31,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "cool"
    ],

--- a/codes/climate/2720.json
+++ b/codes/climate/2720.json
@@ -8,6 +8,7 @@
    "minTemperature":16,
    "maxTemperature":32,
    "precision":1,
+   "unit": "°C",
    "operationModes":[
       "auto",
       "cool",

--- a/codes/climate/2740.json
+++ b/codes/climate/2740.json
@@ -8,6 +8,7 @@
   "minTemperature":16.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/2760.json
+++ b/codes/climate/2760.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 24.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "fan_only"

--- a/codes/climate/2780.json
+++ b/codes/climate/2780.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 0.5,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/2800.json
+++ b/codes/climate/2800.json
@@ -8,6 +8,7 @@
     "minTemperature":16.0,
     "maxTemperature":32.0,
     "precision":1.0,
+    "unit": "°C",
     "operationModes":[
       "heat",
       "cool"

--- a/codes/climate/2801.json
+++ b/codes/climate/2801.json
@@ -8,6 +8,7 @@
     "minTemperature":17.0,
     "maxTemperature":30.0,
     "precision":1.0,
+    "unit": "°C",
     "operationModes":[
       "heat",
       "cool"

--- a/codes/climate/2820.json
+++ b/codes/climate/2820.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "dry",

--- a/codes/climate/2840.json
+++ b/codes/climate/2840.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/2860.json
+++ b/codes/climate/2860.json
@@ -8,6 +8,7 @@
   "minTemperature": 17,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/2880.json
+++ b/codes/climate/2880.json
@@ -8,6 +8,7 @@
     "minTemperature":18,
     "maxTemperature":30,
     "precision":1,
+    "unit": "°C",
     "operationModes":[
       "cool",
       "dry",

--- a/codes/climate/2900.json
+++ b/codes/climate/2900.json
@@ -10,6 +10,7 @@
         "minTemperature": 17,
         "maxTemperature": 30,
         "precision": 1,
+        "unit": "°C",
         "operationModes": [
                 "heat",
                 "cool",

--- a/codes/climate/2920.json
+++ b/codes/climate/2920.json
@@ -8,6 +8,7 @@
    "minTemperature":16.0,
    "maxTemperature":31.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "fan_only",
       "dry",

--- a/codes/climate/2940.json
+++ b/codes/climate/2940.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 32,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool"

--- a/codes/climate/2960.json
+++ b/codes/climate/2960.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/2980.json
+++ b/codes/climate/2980.json
@@ -6,6 +6,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 0.5,
+  "unit": "°C",
   "operationModes": ["heat", "cool", "auto"],
   "fanModes": ["auto"],
   "commands": {

--- a/codes/climate/3000.json
+++ b/codes/climate/3000.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":32,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "heat_cool",
 	"cool",

--- a/codes/climate/3020.json
+++ b/codes/climate/3020.json
@@ -8,6 +8,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 31.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "dry",

--- a/codes/climate/3040.json
+++ b/codes/climate/3040.json
@@ -8,6 +8,7 @@
   "minTemperature":16,
   "maxTemperature":30,
   "precision":1,
+  "unit": "°C",
   "operationModes":[
     "heat",
     "cool",

--- a/codes/climate/3060.json
+++ b/codes/climate/3060.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 31,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "heat",
         "cool",

--- a/codes/climate/3080.json
+++ b/codes/climate/3080.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
       "cool",
       "dry",

--- a/codes/climate/3100.json
+++ b/codes/climate/3100.json
@@ -8,6 +8,7 @@
     "minTemperature": 16,
     "maxTemperature": 30,
     "precision": 1,
+    "unit": "°C",
     "operationModes": [
         "heat",
         "cool",

--- a/codes/climate/3120.json
+++ b/codes/climate/3120.json
@@ -8,6 +8,7 @@
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "heat",
       "cool",

--- a/codes/climate/3140.json
+++ b/codes/climate/3140.json
@@ -8,6 +8,7 @@
    "minTemperature":16.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "fan_only",

--- a/codes/climate/3160.json
+++ b/codes/climate/3160.json
@@ -8,6 +8,7 @@
    "minTemperature":16.0,
    "maxTemperature":31.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "cool",
       "fan_only",

--- a/codes/climate/3180.json
+++ b/codes/climate/3180.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "fan_only"

--- a/codes/climate/3200.json
+++ b/codes/climate/3200.json
@@ -8,6 +8,7 @@
   "minTemperature": 60,
   "maxTemperature": 86,
   "precision": 1,
+  "unit": "°F",
   "operationModes": [
     "cool",
     "dry",

--- a/codes/climate/3220.json
+++ b/codes/climate/3220.json
@@ -16,6 +16,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/3240.json
+++ b/codes/climate/3240.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "dry",

--- a/codes/climate/4060.json
+++ b/codes/climate/4060.json
@@ -8,6 +8,7 @@
   "minTemperature":18.0,
   "maxTemperature":30.0,
   "precision":1.0,
+  "unit": "°C",
   "operationModes":[
     "cool",
     "heat",

--- a/codes/climate/4100.json
+++ b/codes/climate/4100.json
@@ -11,6 +11,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/4129.json
+++ b/codes/climate/4129.json
@@ -8,6 +8,7 @@
     "minTemperature":18.0,
     "maxTemperature":30.0,
     "precision":1.0,
+    "unit": "°C",
     "operationModes":[
       "heat",
       "cool",

--- a/codes/climate/4180.json
+++ b/codes/climate/4180.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/4181.json
+++ b/codes/climate/4181.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/4285.json
+++ b/codes/climate/4285.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/4380.json
+++ b/codes/climate/4380.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/4381.json
+++ b/codes/climate/4381.json
@@ -8,6 +8,7 @@
    "minTemperature":17.0,
    "maxTemperature":30.0,
    "precision":1.0,
+   "unit": "°C",
    "operationModes":[
       "cool"
    ],

--- a/codes/climate/4580.json
+++ b/codes/climate/4580.json
@@ -8,6 +8,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/codes/climate/4800.json
+++ b/codes/climate/4800.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 31.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/5520.json
+++ b/codes/climate/5520.json
@@ -8,6 +8,7 @@
     "minTemperature":16,
     "maxTemperature":30,
     "precision":1,
+    "unit": "°C",
     "operationModes":[  
         "cool",
         "heat",

--- a/codes/climate/7062.json
+++ b/codes/climate/7062.json
@@ -8,6 +8,7 @@
     "minTemperature": 18.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "dry"

--- a/codes/climate/7065.json
+++ b/codes/climate/7065.json
@@ -11,6 +11,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "cool",
         "auto",

--- a/codes/climate/7124.json
+++ b/codes/climate/7124.json
@@ -13,6 +13,7 @@
   "minTemperature": 16,
   "maxTemperature": 31,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/7260.json
+++ b/codes/climate/7260.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/7285.json
+++ b/codes/climate/7285.json
@@ -8,6 +8,7 @@
   "minTemperature": 16.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat",
     "cool",

--- a/codes/climate/7300.json
+++ b/codes/climate/7300.json
@@ -9,6 +9,7 @@
   "minTemperature": 18.0,
   "maxTemperature": 32.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "auto",
     "cool",

--- a/codes/climate/7386.json
+++ b/codes/climate/7386.json
@@ -8,6 +8,7 @@
     "minTemperature": 17.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "auto",
         "cool",

--- a/codes/climate/7740.json
+++ b/codes/climate/7740.json
@@ -8,6 +8,7 @@
   "minTemperature": 17.0,
   "maxTemperature": 30.0,
   "precision": 1.0,
+  "unit": "°C",
   "operationModes": [
     "heat_cool",
     "heat",

--- a/codes/climate/7741.json
+++ b/codes/climate/7741.json
@@ -8,6 +8,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 31.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "feal",
         "cool",

--- a/codes/climate/8700.json
+++ b/codes/climate/8700.json
@@ -8,6 +8,7 @@
     "minTemperature": 16.0,
     "maxTemperature": 30.0,
     "precision": 1.0,
+    "unit": "°C",
     "operationModes": [
         "auto",
         "cool",

--- a/codes/climate/8800.json
+++ b/codes/climate/8800.json
@@ -8,6 +8,7 @@
   "minTemperature": 16,
   "maxTemperature": 30,
   "precision": 1,
+  "unit": "°C",
   "operationModes": [
     "cool",
     "heat",

--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -133,7 +133,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         self._current_temperature = None
         self._current_humidity = None
 
-        self._unit = hass.config.units.temperature_unit
+        self._unit = device_data['unit']
         
         #Supported features
         self._support_flags = SUPPORT_FLAGS


### PR DESCRIPTION
I was previously getting something like 22°F on my control panel. Added a "unit" field to each json config that corresponds to the hard coded temperature and use that instead of assuming the unit is identical to `hass.config.units.temperature_unit`.