### PR TITLE
Update fan.py

### DIFF
--- a/custom_components/smartir/fan.py
+++ b/custom_components/smartir/fan.py
@@ -246,7 +246,7 @@ class SmartIRFan(FanEntity, RestoreEntity):
 
         self.async_write_ha_state()
 
-    async def async_turn_on(self, percentage: int = None, **kwargs):
+    async def async_turn_on(self, percentage: int = None, preset_mode: str = None, **kwargs):
         """Turn on the fan."""
         if percentage is None:
             percentage = ordered_list_item_to_percentage(


### PR DESCRIPTION
This will fix the error coming from Mushroom Fan card "SmartIRFan.async_turn_on() takes from 1 to 2 positional arguments but 3 were given" since is passing also the "preset_mode".