### PR TITLE
Features: press the 'on' button before changing the speed when fan is off

### DIFF
--- a/custom_components/smartir/fan.py
+++ b/custom_components/smartir/fan.py
@@ -248,6 +248,14 @@ class SmartIRFan(FanEntity, RestoreEntity):
 
     async def async_turn_on(self, percentage: int = None, **kwargs):
         """Turn on the fan."""
+        if 'on' in self._commands:
+            command = self._commands['on']
+            try:
+                await self._controller.send(command)
+                await asyncio.sleep(1)
+            except Exception as e:
+                _LOGGER.exception(e)
+
         if percentage is None:
             percentage = ordered_list_item_to_percentage(
                 self._speed_list, self._last_on_speed or self._speed_list[0])


### PR DESCRIPTION
press the 'on' button before changing the speed when fan is off. if the 'on' value is not defined, it keeps the current behaviour.