### PR TITLE
Add `MSZ-GE35VAD` to Broadlink

### DIFF
--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -235,7 +235,7 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 | [1132](../codes/climate/1132.json) | MSC-A12YV                                                                                            | Broadlink  |
 | [1133](../codes/climate/1133.json) | MSXY-FN10VE<br>MSXY-FN07VE<br>MSXY-FN13VE<br>MSXY-FN18VE <b>(Swing mode)</b> <br> MSY-GN18VF         | Broadlink  |
 | [1134](../codes/climate/1134.json) | MG-GN18VF<br>MS-GN18VF<br>MS-GN13VF                                                                  | Broadlink  |
-| [1135](../codes/climate/1135.json) | MSZ-GE60VAD<br>MSZ-GE71VAD<br>MSZ-GE80VAD                                                            | Broadlink  |
+| [1135](../codes/climate/1135.json) | MSZ-GE60VAD<br>MSZ-GE71VAD<br>MSZ-GE80VAD<br>MSZ-GE35VAD                                             | Broadlink  |
 | [1136](../codes/climate/1136.json) | MSXY-FP10VG<br>MSXY-FP13VG<br>MSXY-FP18VG                                                            | Broadlink  |
 | [1137](../codes/climate/1137.json) | MSZ-HR35VF                                                                                           | Broadlink  |
 | [1136](../codes/climate/1138.json) | MSZ-FD25VA-E2 (KM09D/0166901 Remote)                                                                 | Broadlink  |


### PR DESCRIPTION
This code works perfectly fine for my Mitsubishi MSZ-GE35VAD

Product: https://mitsubishi-electric.co.nz/product/nlaproduct.aspx?item=69095B