### PR TITLE
HA 2024 climate compatibility changes

### DIFF
--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -7,10 +7,7 @@ import voluptuous as vol
 
 from homeassistant.components.climate import ClimateEntity, PLATFORM_SCHEMA
 from homeassistant.components.climate.const import (
-    HVAC_MODE_OFF, HVAC_MODE_HEAT, HVAC_MODE_COOL,
-    HVAC_MODE_DRY, HVAC_MODE_FAN_ONLY, HVAC_MODE_AUTO,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_FAN_MODE,
-    SUPPORT_SWING_MODE, HVAC_MODES, ATTR_HVAC_MODE)
+    ClimateEntityFeature, HVACMode, HVAC_MODES, ATTR_HVAC_MODE)
 from homeassistant.const import (
     CONF_NAME, STATE_ON, STATE_OFF, STATE_UNKNOWN, STATE_UNAVAILABLE, ATTR_TEMPERATURE,
     PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE)
@@ -36,8 +33,10 @@ CONF_POWER_SENSOR = 'power_sensor'
 CONF_POWER_SENSOR_RESTORE_STATE = 'power_sensor_restore_state'
 
 SUPPORT_FLAGS = (
-    SUPPORT_TARGET_TEMPERATURE | 
-    SUPPORT_FAN_MODE
+    ClimateEntityFeature.TARGET_TEMPERATURE | 
+    ClimateEntityFeature.FAN_MODE |
+    ClimateEntityFeature.TURN_ON |
+    ClimateEntityFeature.TURN_OFF
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -96,6 +95,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )])
 
 class SmartIRClimate(ClimateEntity, RestoreEntity):
+    _enable_turn_on_off_backwards_compatibility = False
+
     def __init__(self, hass, config, device_data):
         _LOGGER.debug(f"SmartIRClimate init started for device {config.get(CONF_NAME)} supported models {device_data['supportedModels']}")
         self.hass = hass
@@ -119,13 +120,13 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
 
         valid_hvac_modes = [x for x in device_data['operationModes'] if x in HVAC_MODES]
 
-        self._operation_modes = [HVAC_MODE_OFF] + valid_hvac_modes
+        self._operation_modes = [HVACMode.OFF] + valid_hvac_modes
         self._fan_modes = device_data['fanModes']
         self._swing_modes = device_data.get('swingModes')
         self._commands = device_data['commands']
 
         self._target_temperature = self._min_temperature
-        self._hvac_mode = HVAC_MODE_OFF
+        self._hvac_mode = HVACMode.OFF
         self._current_fan_mode = self._fan_modes[0]
         self._current_swing_mode = None
         self._last_on_operation = None
@@ -140,7 +141,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         self._support_swing = False
 
         if self._swing_modes:
-            self._support_flags = self._support_flags | SUPPORT_SWING_MODE
+            self._support_flags = self._support_flags | ClimateEntityFeature.SWING_MODE
             self._current_swing_mode = self._swing_modes[0]
             self._support_swing = True
 
@@ -204,9 +205,9 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
     @property
     def state(self):
         """Return the current state."""
-        if self.hvac_mode != HVAC_MODE_OFF:
+        if self.hvac_mode != HVACMode.OFF:
             return self.hvac_mode
-        return HVAC_MODE_OFF
+        return HVACMode.OFF
 
     @property
     def temperature_unit(self):
@@ -316,7 +317,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             await self.async_set_hvac_mode(hvac_mode)
             return
         
-        if not self._hvac_mode.lower() == HVAC_MODE_OFF:
+        if not self._hvac_mode.lower() == HVACMode.OFF:
             await self.send_command()
 
         self.async_write_ha_state()
@@ -325,7 +326,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         """Set operation mode."""
         self._hvac_mode = hvac_mode
         
-        if not hvac_mode == HVAC_MODE_OFF:
+        if not hvac_mode == HVACMode.OFF:
             self._last_on_operation = hvac_mode
 
         await self.send_command()
@@ -335,7 +336,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         """Set fan mode."""
         self._current_fan_mode = fan_mode
         
-        if not self._hvac_mode.lower() == HVAC_MODE_OFF:
+        if not self._hvac_mode.lower() == HVACMode.OFF:
             await self.send_command()      
         self.async_write_ha_state()
 
@@ -343,13 +344,13 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         """Set swing mode."""
         self._current_swing_mode = swing_mode
 
-        if not self._hvac_mode.lower() == HVAC_MODE_OFF:
+        if not self._hvac_mode.lower() == HVACMode.OFF:
             await self.send_command()
         self.async_write_ha_state()
 
     async def async_turn_off(self):
         """Turn off."""
-        await self.async_set_hvac_mode(HVAC_MODE_OFF)
+        await self.async_set_hvac_mode(HVACMode.OFF)
         
     async def async_turn_on(self):
         """Turn on."""
@@ -367,7 +368,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
                 swing_mode = self._current_swing_mode
                 target_temperature = '{0:g}'.format(self._target_temperature)
 
-                if operation_mode.lower() == HVAC_MODE_OFF:
+                if operation_mode.lower() == HVACMode.OFF:
                     await self._controller.send(self._commands['off'])
                     return
 
@@ -409,7 +410,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
         if old_state is not None and new_state.state == old_state.state:
             return
 
-        if new_state.state == STATE_ON and self._hvac_mode == HVAC_MODE_OFF:
+        if new_state.state == STATE_ON and self._hvac_mode == HVACMode.OFF:
             self._on_by_remote = True
             if self._power_sensor_restore_state == True and self._last_on_operation is not None:
                 self._hvac_mode = self._last_on_operation
@@ -420,8 +421,8 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
 
         if new_state.state == STATE_OFF:
             self._on_by_remote = False
-            if self._hvac_mode != HVAC_MODE_OFF:
-                self._hvac_mode = HVAC_MODE_OFF
+            if self._hvac_mode != HVACMode.OFF:
+                self._hvac_mode = HVACMode.OFF
             self.async_write_ha_state()
 
     @callback


### PR DESCRIPTION
This is PR containing compatibility fixes for recent HA climate changes. Those shall fix warning and error as bellow. 

Changes summary:
replacement of HVAC_MODE_ 
corrected SUPPORTED_FEATURES
added ClimateEntityFeature flags

as per:
https://developers.home-assistant.io/docs/core/entity/climate/ https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/ https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/

Related errors and warnings:
```
Log details (WARNING)
Logger: homeassistant.components.climate
Source: components/climate/__init__.py:361
integration: Climate (documentation, issues)
First occurred: 3:19:30 PM (7 occurrences)
Last logged: 3:19:30 PM

Entity None (<class 'custom_components.smartir.climate.SmartIRClimate'>) implements HVACMode(s): off, heat, cool, heat_cool, dry, fan_only and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please report it to the author of the 'smartir' custom integration



Logger: homeassistant.components.climate
Source: components/climate/__init__.py:361
integration: Climate (documentation, issues)
First occurred: 4:41:50 PM (4 occurrences)
Last logged: 4:41:51 PM

Entity None (<class 'custom_components.smartir.climate.SmartIRClimate'>) does not set ClimateEntityFeature.TURN_OFF but implements the turn_off method. Please report it to the author of the 'smartir' custom integration
Entity None (<class 'custom_components.smartir.climate.SmartIRClimate'>) does not set ClimateEntityFeature.TURN_ON but implements the turn_on method. Please report it to the author of the 'smartir' custom integration
Entity None (<class 'custom_components.smartir.climate.SmartIRClimate'>) implements HVACMode(s): off, heat, cool, heat_cool, dry, fan_only and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please report it to the author of the 'smartir' custom integration
Entity climate.heating_dhw (<class 'custom_components.climate_template.climate.TemplateClimate'>) implements HVACMode(s): heat, off and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please create a bug report at https://github.com/jcwillox/hass-template-climate/issues




Logger: homeassistant.helpers.entity
Source: helpers/entity.py:1597
First occurred: 4:41:50 PM (1 occurrences)
Last logged: 4:41:50 PM

Entity None (<class 'custom_components.smartir.climate.SmartIRClimate'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <ClimateEntityFeature.TARGET_TEMPERATURE|FAN_MODE: 9>, please report it to the author of the 'smartir' custom integration and reference https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation




Logger: homeassistant.components.climate.const
Source: helpers/deprecation.py:205
integration: Climate (documentation, issues)
First occurred: 4:41:49 PM (9 occurrences)
Last logged: 4:41:49 PM

HVAC_MODE_FAN_ONLY was used from smartir, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.FAN_ONLY instead, please report it to the author of the 'smartir' custom integration
HVAC_MODE_AUTO was used from smartir, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.AUTO instead, please report it to the author of the 'smartir' custom integration
SUPPORT_TARGET_TEMPERATURE was used from smartir, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.TARGET_TEMPERATURE instead, please report it to the author of the 'smartir' custom integration
SUPPORT_FAN_MODE was used from smartir, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.FAN_MODE instead, please report it to the author of the 'smartir' custom integration
SUPPORT_SWING_MODE was used from smartir, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.SWING_MODE instead, please report it to the author of the 'smartir' custom integration

```