### PR TITLE
Added new remote control unit compatibility for AR-PZ2

### DIFF
--- a/codes/climate/1285.json
+++ b/codes/climate/1285.json
@@ -1,7 +1,8 @@
 {
    "manufacturer":"Fujitsu",
    "supportedModels":[
-      "AR-RCE1E"
+      "AR-RCE1E",
+      "AR-PZ2"
    ],
    "supportedController":"Broadlink",
    "commandsEncoding":"Base64",

--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -308,7 +308,7 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 | [1282](../codes/climate/1282.json) | AR-JW11 (Remote control)                                                | Broadlink   |
 | [1283](../codes/climate/1283.json) | AR-AB5 (Remote control)                                                 | Broadlink   |
 | [1284](../codes/climate/1284.json) | AR-REG1U (Remote control)                                               | Broadlink   |
-| [1285](../codes/climate/1285.json) | AR-RCE1E (Remote control)                                               | Broadlink   |
+| [1285](../codes/climate/1285.json) | AR-RCE1E (Remote control)<br>AR-PZ2                                     | Broadlink   |
 | [4285](../codes/climate/4285.json) | AR-RCE1E (Remote control)                                               | Xiaomi (v2) |
 | [7285](../codes/climate/7285.json) | AR-RCE1E (Remote control)                                               | ESPHome     |
 | [1286](../codes/climate/1286.json) | AR-JE5 (Remote control)                                                 | Broadlink   |


### PR DESCRIPTION
Using broadlink RM4 pro the existing 1285 codes are found to work well with the AR-PZ2 remote too.