### PR TITLE
Update the temperature range for Daikin 1118 (FTXS24LVJU)

### DIFF
--- a/codes/climate/1118.json
+++ b/codes/climate/1118.json
@@ -10,8 +10,8 @@
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",
-  "minTemperature": 20.0,
-  "maxTemperature": 26.0,
+  "minTemperature": 18.0,
+  "maxTemperature": 30.0,
   "precision": 1.0,
   "operationModes": [
     "cool",


### PR DESCRIPTION
This PR updates the temperate range for Daikin aircon remotes according to the manual.

<img width="758" alt="Screenshot 2024-08-28 at 2 24 21 PM" src="https://github.com/user-attachments/assets/8ebbd734-02d9-49e9-b8e5-3458e7e322da">

[manual.pdf](https://github.com/user-attachments/files/16776304/manual.pdf)
 