### PR TITLE
Add DG11L1-12 as supported remote

### DIFF
--- a/codes/climate/1522.json
+++ b/codes/climate/1522.json
@@ -1,7 +1,8 @@
 {
   "manufacturer": "Hisense",
   "supportedModels": [
-    "DGR11R2"
+    "DGR11R2",
+    "DG11L1-12"
   ],
   "supportedController": "Broadlink",
   "commandsEncoding": "Base64",


### PR DESCRIPTION
Tested and working with my DG11L1-12 remote on a HiSense CA35YR03G mini split unit.