### PR TITLE
Add support for Pioneer VSX-1014 on MQTT controller

### DIFF
--- a/codes/media_player/1410.json
+++ b/codes/media_player/1410.json
@@ -1,0 +1,18 @@
+{
+  "manufacturer": "Pioneer",
+  "supportedModels": [
+    "VSX-1014"
+  ],
+  "supportedController": "MQTT",
+  "commandsEncoding": "Raw",
+  "commands": {
+    "off": "{\"ir_code_to_send\": \"DWMhchBCAvwFQgLdAUICwAfgAwvAE+ADB+ADC0ArwANAF8ADwBNAB+ATE0AbA+FjYyHg/YcghwIFQgI=\"}",
+    "on": "{\"ir_code_to_send\": \"DWMhchBCAvwFQgLdAUICwAfgAwvAE+ADB+ADC0ArwANAF8ADwBNAB+ATE0AbA+FjYyHg/YcghwIFQgI=\"}",
+    "volumeDown": "{\"ir_code_to_send\": \"DYohhxBRAvcFUQLiAVECwAfgAwvAE+ADB+ADC8Ar4AcTQBfgBwPgAyNAC8ADAahj4P2HYIcCBVEC\"}",
+    "volumeUp": "{\"ir_code_to_send\": \"CUcC9wVHAtcBRwJAB0ADwAtAB0AD4AsTQBdAA+AHG0AP4AMDB9tjgSF1EEcCQBPgAy/gAwvgBxtAD0AD4AMj4AMLwBtAE8ADwBPgAwdAC8AD4HyHAgVHAg==\"}",
+    "mute": "{\"ir_code_to_send\": \"DW4hjhBJAvQFSQLXAUkCwAfgAwvAE+ADB+ADC0ArQAPAE+AHC+ADD0AjQAPAE0ALQAMBtmPg/YdghwIFSQI=\"}",
+    "sources": {
+          "TV/Sat": "{\"ir_code_to_send\": \"DXQhixBKAvQFSgLUAUoCwAfgAwvAE+ADB+ADC0ArwANAF0ADwA/AB0ATQAPgBw9AE0ADActj4P2H4ISHAgVKAg==\"}"
+    }
+  }
+}

--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -220,6 +220,10 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
     async def async_turn_off(self):
         """Turn the media player off."""
+        if self._power_sensor is not None and self._state == STATE_OFF:
+            # Media player is already off
+            return
+            
         await self.send_command(self._commands['off'])
         
         if self._power_sensor is None:
@@ -229,6 +233,10 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
     async def async_turn_on(self):
         """Turn the media player off."""
+        if self._power_sensor is not None and self._state == STATE_ON:
+            # Media player is already on
+            return
+            
         await self.send_command(self._commands['on'])
 
         if self._power_sensor is None:

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -259,6 +259,7 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 | Code | Supported Models | Controller |
 | ------------- | -------------------------- | ------------- |
 [1400](../codes/media_player/1400.json)| X-CM56 |Broadlink
+[1410](../codes/media_player/1410.json)| VSX-1014 |MQTT
 
 #### JBL
 | Code | Supported Models | Controller |


### PR DESCRIPTION
I added a json for the (basic) codes of the pioneer VSX-1014. On/off (toggle, same code), volume and mute are supported and tested using a MOES UFO-R11 and zigbee2mqtt.