### PR TITLE
Set minumum HA version to 2025.1.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "SmartIR",
-  "homeassistant": "2023.12.0",
+  "homeassistant": "2025.1.0",
   "persistent_directory": "codes"
 }


### PR DESCRIPTION
Since 1.17.13 introduces changes that are only compatible with HA version 2025.1.0 and on, the minimum required version in hacs.json should be updated to reflect that.