### PR TITLE
new controller via script with payload

### DIFF
--- a/custom_components/smartir/controller.py
+++ b/custom_components/smartir/controller.py
@@ -15,6 +15,7 @@ XIAOMI_CONTROLLER = 'Xiaomi'
 MQTT_CONTROLLER = 'MQTT'
 LOOKIN_CONTROLLER = 'LOOKin'
 ESPHOME_CONTROLLER = 'ESPHome'
+SCRIPT_CONTROLLER = 'Script'
 
 ENC_BASE64 = 'Base64'
 ENC_HEX = 'Hex'
@@ -26,7 +27,7 @@ XIAOMI_COMMANDS_ENCODING = [ENC_PRONTO, ENC_RAW]
 MQTT_COMMANDS_ENCODING = [ENC_RAW]
 LOOKIN_COMMANDS_ENCODING = [ENC_PRONTO, ENC_RAW]
 ESPHOME_COMMANDS_ENCODING = [ENC_RAW]
-
+SCRIPT_CONTROLLER_ENCODING = [ENC_BASE64]
 
 def get_controller(hass, controller, encoding, controller_data, delay):
     """Return a controller compatible with the specification provided."""
@@ -35,7 +36,8 @@ def get_controller(hass, controller, encoding, controller_data, delay):
         XIAOMI_CONTROLLER: XiaomiController,
         MQTT_CONTROLLER: MQTTController,
         LOOKIN_CONTROLLER: LookinController,
-        ESPHOME_CONTROLLER: ESPHomeController
+        ESPHOME_CONTROLLER: ESPHomeController,
+        SCRIPT_CONTROLLER: ScriptController
     }
     try:
         return controllers[controller](hass, controller, encoding, controller_data, delay)
@@ -150,6 +152,28 @@ class MQTTController(AbstractController):
 
         await self.hass.services.async_call(
             'mqtt', 'publish', service_data)
+
+
+class ScriptController(AbstractController):
+    """Controls a Script ."""
+
+    def check_encoding(self, encoding):
+        """Check if the encoding is supported by the controller."""
+        if encoding not in SCRIPT_CONTROLLER_ENCODING:
+            raise Exception("The encoding is not supported "
+                            "by the script controller.")
+
+    async def send(self, command):
+        """Send a command."""
+        service_data = {
+            'entity_id': self._controller_data,
+            'variables': {
+                'payload': command
+            }
+        }
+
+        await self.hass.services.async_call(
+            'script', 'turn_on', service_data)
 
 
 class LookinController(AbstractController):


### PR DESCRIPTION
I'm using ZosungIRBlaster and ZHA(without MQTT) and it`s only one way to controlling my devices.
Example of codes device config:
```
  "supportedController":"Script",
  "commandsEncoding":"Base64",
```
Example of config contoller_data:
```
climate:
  - platform: smartir
    name: Office AC
    unique_id: office_ac
    device_code: 1000
    controller_data: script.controller_ir_blaster
    temperature_sensor: sensor.temperature
    humidity_sensor: sensor.humidity
    power_sensor: binary_sensor.ac_power
```

Example of script: 
```
action: zha.issue_zigbee_cluster_command
data:
  cluster_type: in
  ieee: ff:ff:ff:ff:ff:ff:ff:ff
  endpoint_id: 1
  cluster_id: 57348
  command: 2
  command_type: server
  params: 
    code: "{{payload}}"
```

I think it may be useful for someone who use the same device or want to easy to create custom integration.