### PR TITLE
ESPHome services are now called actions

### DIFF
--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -96,8 +96,8 @@ esphome:
   board: esp01_1m
 
 api:
-  services:
-    - service: send_raw_command
+  actions:
+    - action: send_raw_command
       variables:
         command: int[]
       then:

--- a/docs/FAN.md
+++ b/docs/FAN.md
@@ -88,8 +88,8 @@ esphome:
   board: esp01_1m
 
 api:
-  services:
-    - service: send_raw_command
+  actions:
+    - action: send_raw_command
       variables:
         command: int[]
       then:

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -82,8 +82,8 @@ esphome:
   board: esp01_1m
 
 api:
-  services:
-    - service: send_raw_command
+  actions:
+    - action: send_raw_command
       variables:
         command: int[]
       then:


### PR DESCRIPTION
Native API Component https://esphome.io/components/api.html#native-api-component
Actions were previously called Services. ESPHome changed the name in line with Home Assistant
https://developers.home-assistant.io/blog/2024/07/16/service-actions/
but will continue to support YAML with services and homeassistant.service for the foreseeable future. Documentation will only refer to Actions.