### PR TITLE
Fix temperature unit conversion for Fahrenheit display

### DIFF
--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -197,7 +197,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             self._hvac_mode = last_state.state
             self._current_fan_mode = last_state.attributes['fan_mode']
             self._current_swing_mode = last_state.attributes.get('swing_mode')
-            self._target_temperature = last_state.attributes['temperature']
+            self._target_temperature = self._display_temp_to_device_temp(last_state.attributes['temperature'])
 
             if 'last_on_operation' in last_state.attributes:
                 self._last_on_operation = last_state.attributes['last_on_operation']


### PR DESCRIPTION
  ## Summary
  Fixes temperature display when Home Assistant is configured to use Fahrenheit. Previously, the component displayed
   Celsius values with the °F symbol, causing confusion for users in Fahrenheit-using regions.

  Relevant issue: https://github.com/smartHomeHub/SmartIR/issues/1042

  ## Changes
  - Added automatic temperature unit conversion based on Home Assistant's configured unit
  - Auto-detects device temperature unit from JSON (Celsius or Fahrenheit)
  - Devices with `minTemperature > 40` are inferred as Fahrenheit (e.g., General Electric models)
  - Future device files can explicitly specify `"temperatureUnit": "°F"` or `"°C"`

  ## Implementation Details
  - Device temperatures (min/max/target from JSON) are stored in the device's native unit
  - Display temperatures are converted to Home Assistant's configured unit
  - User input is converted back to device unit before sending IR commands
  - Temperature sensor readings remain unconverted (already in HA's configured unit)

  ## Supported Scenarios
  | Device Unit | HA Config | Behavior |
  |-------------|-----------|----------|
  | Celsius | Celsius | No conversion (existing behavior) |
  | Celsius | Fahrenheit | Converts C → F for display |
  | Fahrenheit | Fahrenheit | No conversion |
  | Fahrenheit | Celsius | Converts F → C for display |