### PR TITLE
Fix compatibility with Home Assistant 2025.12.2+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+custom_components/smartir/__pycache__/

--- a/custom_components/smartir/__init__.py
+++ b/custom_components/smartir/__init__.py
@@ -2,7 +2,7 @@ import aiofiles
 import aiohttp
 import asyncio
 import binascii
-from distutils.version import StrictVersion
+from packaging import version
 import json
 import logging
 import os.path
@@ -77,14 +77,14 @@ async def _update(hass, branch, do_update=False, notify_if_latest=True):
                     last_version = data['updater']['version']
                     release_notes = data['updater']['releaseNotes']
 
-                    if StrictVersion(last_version) <= StrictVersion(VERSION):
+                    if version.parse(last_version) <= version.parse(VERSION):
                         if notify_if_latest:
                             hass.components.persistent_notification.async_create(
                                 "You're already using the latest version!", 
                                 title='SmartIR')
                         return
 
-                    if StrictVersion(current_ha_version) < StrictVersion(min_ha_version):
+                    if version.parse(current_ha_version) < version.parse(min_ha_version):
                         hass.components.persistent_notification.async_create(
                             "There is a new version of SmartIR integration, but it is **incompatible** "
                             "with your system. Please first update Home Assistant.", title='SmartIR')

--- a/custom_components/smartir/manifest.json
+++ b/custom_components/smartir/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/smartHomeHub/SmartIR",
   "dependencies": [],
   "codeowners": ["@smartHomeHub"],
-  "requirements": ["aiofiles>=0.6.0"],
+  "requirements": ["aiofiles>=0.6.0", "packaging>=20.0"],
   "homeassistant": "2025.5.0",
   "version": "1.18.1",
   "updater": {


### PR DESCRIPTION
 # Fix Home Assistant 2025.12.2+ Compatibility
 
 ## Summary
 This PR updates SmartIR to support Home Assistant versions 2025.12.2 and higher by replacing the deprecated `distutils` module with the `packaging` library.
 
 ## Changes
 - **Replaced deprecated import**: Changed from `distutils.version.StrictVersion` to `packaging.version.parse()`
 - **Updated version comparisons**: All version comparison logic now uses `packaging.version.parse()` instead of `StrictVersion`
 - **Added dependency**: Added `packaging>=20.0` to the `requirements` in `manifest.json`
 - **Added `.gitignore`**: Ignore `__pycache__` directories for cleaner repository
 
 ## Background
 Python 3.12+ removed the `distutils` module, which was deprecated in Python 3.10. Home Assistant 2025.12.2 and later versions use Python 3.12+, causing SmartIR to fail on import due to the missing 
`distutils.version` module.
 
 The `packaging` library is the recommended replacement and provides equivalent functionality through `version.parse()`.
 
 ## Testing
 - [x] Version comparison logic remains functionally identical
 - [x] Compatible with Home Assistant 2025.12.2+
 - [x] Backward compatible with older Home Assistant versions
 
 ## Related Issues
 Resolves compatibility issues with Home Assistant 2025.12.2+ and Python 3.12+
 
 ## Notes
 As this repository seems to be unmaintained, I have created a fork that includes changes on this PR for users needing this integration working right now: https://github.com/notf0und/SmartIR
