### PR TITLE
Added more split units to applicable codes in CLIMATE.md

### DIFF
--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -214,7 +214,7 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 | [1114](../codes/climate/1114.json) | FTXM35UVMZ                                                                                                                                           | Broadlink  |
 | [1115](../codes/climate/1115.json) | FTXB-C                                                                                                                                           | Broadlink  |
 | [1116](../codes/climate/1116.json) | FCQ100KAVEA                                  | Broadlink  |
-| [1117](../codes/climate/1117.json) | DTXF35TVMA                                                                                           | Broadlink  |
+| [1117](../codes/climate/1117.json) | DTXF35TVMA<br>FTX18UVJU<br>FTX24UVJU | Broadlink  |
 | [1118](../codes/climate/1118.json) | ARC452A21<br>FTXS09LVJU<br>FTXS12LVJU<br>FTXS15LVJU<br>FTXS18LVJU<br>FTXS24LVJU<br> | Broadlink  |
 | [1119](../codes/climate/1119.json) | FTXS60FVMA                                                                                           | Broadlink  |
 | [4100](../codes/climate/4100.json) | FTXS25CVMB<br>FTXS35CVMB<br>FTXS60BVMB<br>FVXS25BVMB                                                 | Xiaomi     |

--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -316,7 +316,7 @@ Contributing to your own code files is welcome. However, we do not accept incomp
 | [1282](../codes/climate/1282.json) | AR-JW11 (Remote control)                                                | Broadlink   |
 | [1283](../codes/climate/1283.json) | AR-AB5 (Remote control)                                                 | Broadlink   |
 | [1284](../codes/climate/1284.json) | AR-REG1U (Remote control)                                               | Broadlink   |
-| [1285](../codes/climate/1285.json) | AR-RCE1E (Remote control)<br>AR-PZ2                                     | Broadlink   |
+| [1285](../codes/climate/1285.json) | AR-RCE1E (Remote control)<br>AR-REG1U with AGU9RLF<br>AR-PZ2            | Broadlink   |
 | [4285](../codes/climate/4285.json) | AR-RCE1E (Remote control)                                               | Xiaomi (v2) |
 | [7285](../codes/climate/7285.json) | AR-RCE1E (Remote control)                                               | ESPHome     |
 | [1286](../codes/climate/1286.json) | AR-JE5 (Remote control)                                                 | Broadlink   |


### PR DESCRIPTION
Daikin FTX18UVJU and FTX24UVJU use code 1117
Fujitsu AGU9RLF with remote AR-REG1U uses code 1285