### PR TITLE
Fix highest/lowest light brightness value resync

### DIFF
--- a/custom_components/smartir/light.py
+++ b/custom_components/smartir/light.py
@@ -327,7 +327,7 @@ class SmartIRLight(LightEntity, RestoreEntity):
                         new_brightness == len(self._brightnesses) - 1
                         or new_brightness == 0
                     ):
-                        steps = len(self._colortemps)
+                        steps = len(self._brightnesses)
                     did_something = True
                     self._brightness = self._brightnesses[new_brightness]
                     await self.send_command(cmd, steps)


### PR DESCRIPTION
When trying to resync the state of brightness by issuing enough commands to go the full range when the highest or lowest value is requested:

Fix reading the length of color temperature list instead of brightness list 

---

Before this change, if the color temps list is smaller than the brightness list, the sync is not achieved. Moreover, it desyncs instead.

For example, let's say the brightness list is [10,20,30,40,50,60,70,80,90,100,200,255] and the color temp list is [2700, 6000]. In this case trying to from brightness 20 to brightness 255 will actually perform 2 steps up, and the light will have the brightness of 40, while the entity state will assume we are at 255.